### PR TITLE
[iOS] Not to use SwiftGenPlugin package to avoid high cpu usage

### DIFF
--- a/app-ios/DroidKaigi2022/DroidKaigi2022.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app-ios/DroidKaigi2022/DroidKaigi2022.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -55,15 +55,6 @@
       }
     },
     {
-      "identity" : "swiftgenplugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftGen/SwiftGenPlugin",
-      "state" : {
-        "revision" : "879b85a470cacd70c19e22eb7e11a3aed66f4068",
-        "version" : "6.6.2"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/app-ios/Package.swift
+++ b/app-ios/Package.swift
@@ -18,7 +18,6 @@ var package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.39.1"),
-        .package(url: "https://github.com/SwiftGen/SwiftGenPlugin", from: "6.6.2"),
     ],
     targets: [
         .target(
@@ -42,7 +41,7 @@ var package = Package(
                 .process("Resources"),
             ],
             plugins: [
-                .plugin(name: "SwiftGenPlugin", package: "SwiftGenPlugin"),
+                .plugin(name: "SwiftGenPlugin"),
             ]
         ),
         .target(
@@ -67,10 +66,22 @@ var package = Package(
                 .target(name: "SwiftLintBinary"),
             ]
         ),
+        .plugin(
+            name: "SwiftGenPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                .target(name: "swiftgen"),
+            ]
+        ),
         .binaryTarget(
             name: "SwiftLintBinary",
             url: "https://github.com/realm/SwiftLint/releases/download/0.48.0/SwiftLintBinary-macos.artifactbundle.zip",
             checksum: "9c255e797260054296f9e4e4cd7e1339a15093d75f7c4227b9568d63edddba50"
+        ),
+        .binaryTarget(
+          name: "swiftgen",
+          url: "https://github.com/SwiftGen/SwiftGen/releases/download/6.6.2/swiftgen-6.6.2.artifactbundle.zip",
+          checksum: "7586363e24edcf18c2da3ef90f379e9559c1453f48ef5e8fbc0b818fbbc3a045"
         ),
     ]
 )

--- a/app-ios/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/app-ios/Plugins/SwiftGenPlugin/Plugin.swift
@@ -1,0 +1,30 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct SwiftGenPlugins: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let configurations: [Path] = [context.package.directory, target.directory]
+          .map { $0.appending("swiftgen.yml") }
+
+        return try configurations.map { configuration in
+            return Command.prebuildCommand(
+                displayName: "SwiftGen",
+                executable: try context.tool(named: "swiftgen").path,
+                arguments: [
+                    "config",
+                    "run",
+                    "--verbose",
+                    "--config", "\(configuration)"
+                ],
+                environment: [
+                  "PROJECT_DIR": context.package.directory,
+                  "TARGET_NAME": target.name,
+                  "PRODUCT_MODULE_NAME": (target as? SourceModuleTarget)?.moduleName ?? "",
+                  "DERIVED_SOURCES_DIR": context.pluginWorkDirectory
+                ],
+                outputFilesDirectory: context.pluginWorkDirectory
+            )
+        }
+    }
+}


### PR DESCRIPTION
related issues:

- https://forums.swift.org/t/spm-plugin-with-binary-target-high-cpu-usage/59535
- https://github.com/SwiftGen/SwiftGenPlugin/issues/2

According to these issues, artifact-bundle causes this problem, but it isn't caused by artifact-bundle in my environment. So I will use own plugin instead of plugin package experimentally.