### PR TITLE
[Proposal]Fix timetable scrolling

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Changed to make it easier to scroll because diagonal scrolling is not possible with a combination of vertical scrolling and horizontal scrolling.
- However, there is a issue that vertical nested scroll cannot be used because it is not scrollable when using `detectDragGestures`. 
  - #103 may be difficult to implement.   

## Links
-

## Screenshot
Before | After
:--: | :--:
<video src="https://user-images.githubusercontent.com/13705006/188302414-e8b40264-3851-4eff-a7bd-0e609305645f.mp4" /> | <video src="https://user-images.githubusercontent.com/13705006/188302384-6e2b7501-0e80-490c-a74a-ceb921ae42aa.mp4" />


