### PR TITLE
Add missing spaces in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,4 +269,4 @@ https://github.com/DroidKaigi/conference-app-2022/blob/91715b461b3162eb04ac58b79
 * [Contributors](https://github.com/DroidKaigi/conference-app-2022/graphs/contributors)
 * Designer [Chihokotaro / Chihoko Watanabe](https://twitter.com/chihokotaro)
 * Oversight of Material Design3 [Nabe](https://twitter.com/NabeCott)
-* API Server[RyuNen344](https://twitter.com/RyuNen344)
+* API Server [RyuNen344](https://twitter.com/RyuNen344)


### PR DESCRIPTION
## Overview

In the Special Thanks part, there is a space between the session and the mention, but only the last API Server session does not contain a space between the mentions. Added missing whitespace for document readability and unifying style.

## Screenshot

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/40740128/188464592-b5ba803e-5548-48cc-8508-9df58751e261.png" width="300" /> | <img src="https://user-images.githubusercontent.com/40740128/188464622-2ea44f80-475a-454c-8f6c-dbb0ba5f95d4.png" width="300" />
