### PR TITLE
fix tab title day size

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
@@ -50,7 +50,7 @@ internal fun SessionDayTab(
                 style = TextStyle(
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    fontSize = 16.sp,
+                    fontSize = 24.sp,
                     fontWeight = FontWeight(500)
                 ),
                 modifier = Modifier.fillMaxWidth()


### PR DESCRIPTION
## Issue
- close #158

## Overview (Required)
- fixed the text size of SessionDayTab's day size from 16sp to 24sp

## Links
- https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=448%3A2009

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/12797442/188471491-49908b59-7035-43a6-8bb2-3e5b81aa0c45.png" width="300" /> | <img src="https://user-images.githubusercontent.com/12797442/188471529-6449ccaa-e6ec-4a79-a021-859835c8ec46.png" width="300" />