### PR TITLE
Fixed #170, Navigate from sessions list to session's detail

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2022.feature.sessions
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,6 +30,7 @@ import io.github.droidkaigi.confsched2022.model.TimetableItemId
 fun SessionListItem(
     timetableItem: TimetableItem,
     isFavorited: Boolean,
+    onTimetableClick: (timetableItemId: TimetableItemId) -> Unit,
     onFavoriteClick: (TimetableItemId, Boolean) -> Unit,
     modifier: Modifier = Modifier,
     maxTitleLines: Int = 4
@@ -38,6 +40,7 @@ fun SessionListItem(
     Row(
         modifier = modifier
             .fillMaxSize()
+            .clickable { onTimetableClick(timetableItem.id) }
             .semantics { contentDescription = "isFavorited$isFavorited" },
         horizontalArrangement = Arrangement.SpaceBetween
     ) {

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -114,6 +114,7 @@ fun Sessions(
                         pagerState = pagerState,
                         scheduleState = scheduleState,
                         days = days,
+                        onTimetableClick = onTimetableClick,
                         onFavoriteClick = onFavoriteClick
                     )
                 }
@@ -172,6 +173,7 @@ fun SessionsList(
     pagerState: PagerState,
     scheduleState: Loaded,
     days: Array<DroidKaigi2022Day>,
+    onTimetableClick: (timetableItemId: TimetableItemId) -> Unit,
     onFavoriteClick: (TimetableItemId, Boolean) -> Unit,
 ) {
     HorizontalPager(
@@ -184,6 +186,7 @@ fun SessionsList(
             SessionListItem(
                 timetableItem = timetableItem,
                 isFavorited = isFavorited,
+                onTimetableClick = onTimetableClick,
                 onFavoriteClick = onFavoriteClick
             )
         }


### PR DESCRIPTION
## Issue
- close #170

## Overview (Required)
- move from list to detail screen
- pass onTimetableClick like to "Timetable" Composable as parameter
  - "Timetable" declared "Clickable" outside of Composable, but I applied it to SessionListItem. There doesn't seem to be any rules for where you should write your Clickables. 
  - If exist, let me know.

## Screenshot
https://user-images.githubusercontent.com/1534926/188482936-c87574e9-6dda-4e58-8df3-682e846f5215.mp4