### PR TITLE
Remove redundant label in AndroidManifest

### DIFF
--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
         <activity
             android:name="io.github.droidkaigi.confsched2022.MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.DroidKaigi.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
The activity-label in AndroidManifest is redundant if it is the same as the application-label.
As far as I know, currently the activity-label is displayed only in "Recent Apps" on older OSes.
There was a Lint warning, so I just deleted it for now, but nothing changed.
<img src="https://user-images.githubusercontent.com/11440952/188484186-e294f7ce-a995-48b9-9a79-2602c410da52.png" width="500" />

## Links
- https://developer.android.com/guide/topics/manifest/activity-element

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/11440952/188484582-11d3998b-b5da-41ac-9151-526231229305.png" width="300" /> | nothing changed

