### PR TITLE
Fix ktlint import layout and match it with Android Studio's default order

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/SpotlessPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/SpotlessPlugin.kt
@@ -15,9 +15,11 @@ class SpotlessPlugin : Plugin<Project> {
                 kotlin {
                     target("**/*.kt")
                     targetExclude("**/build/**/*.kt")
-                    ktlint(
-                        libs.findVersion("ktlint").get().toString()
-                    ).userData(mapOf("android" to "true"))
+                    ktlint(libs.findVersion("ktlint").get().toString())
+                        .userData(mapOf("android" to "true"))
+                        .editorConfigOverride(
+                            mapOf("ij_kotlin_imports_layout" to "*,java.**,javax.**,kotlin.**,^")
+                        )
                 }
                 format("kts") {
                     target("**/*.kts")

--- a/core-data/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/data/di/ApiModule.kt
+++ b/core-data/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/data/di/ApiModule.kt
@@ -18,9 +18,9 @@ import io.github.droidkaigi.confsched2022.data.auth.AuthenticatorImpl
 import io.github.droidkaigi.confsched2022.data.sessions.defaultKtorConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
-import javax.inject.Singleton
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module

--- a/core-zipline/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/zipline/SessionsZipline.kt
+++ b/core-zipline/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/zipline/SessionsZipline.kt
@@ -6,9 +6,6 @@ import app.cash.zipline.Zipline
 import app.cash.zipline.loader.ZiplineLoader
 import co.touchlab.kermit.Logger
 import io.github.droidkaigi.confsched2022.model.DroidKaigiSchedule
-import java.util.concurrent.Executors
-import javax.inject.Inject
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +15,9 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
+import java.util.concurrent.Executors
+import javax.inject.Inject
+import kotlin.coroutines.EmptyCoroutineContext
 
 class SessionsZipline @Inject constructor(
     context: Application,

--- a/feature-about/src/test/java/io/github/droidkaigi/confsched2022/feature/about/AboutScreenTest.kt
+++ b/feature-about/src/test/java/io/github/droidkaigi/confsched2022/feature/about/AboutScreenTest.kt
@@ -3,10 +3,10 @@ package io.github.droidkaigi.confsched2022.feature.about
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.droidkaigi.confsched2022.testing.RobotTestRule
-import javax.inject.Inject
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import javax.inject.Inject
 
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsViewModel.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsViewModel.kt
@@ -14,8 +14,8 @@ import io.github.droidkaigi.confsched2022.model.ContributorsRepository
 import io.github.droidkaigi.confsched2022.ui.Result
 import io.github.droidkaigi.confsched2022.ui.asResult
 import io.github.droidkaigi.confsched2022.ui.moleculeComposeState
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
 
 @HiltViewModel
 class ContributorsViewModel @Inject constructor(

--- a/feature-contributors/src/test/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsScreenTest.kt
+++ b/feature-contributors/src/test/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsScreenTest.kt
@@ -3,10 +3,10 @@ package io.github.droidkaigi.confsched2022.feature.contributors
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.droidkaigi.confsched2022.testing.RobotTestRule
-import javax.inject.Inject
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import javax.inject.Inject
 
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetailViewModel.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetailViewModel.kt
@@ -16,9 +16,9 @@ import io.github.droidkaigi.confsched2022.model.TimetableItemId
 import io.github.droidkaigi.confsched2022.ui.Result
 import io.github.droidkaigi.confsched2022.ui.asResult
 import io.github.droidkaigi.confsched2022.ui.moleculeComposeState
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class SessionDetailViewModel @Inject constructor(

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsViewModel.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsViewModel.kt
@@ -19,12 +19,12 @@ import io.github.droidkaigi.confsched2022.ui.Result
 import io.github.droidkaigi.confsched2022.ui.asResult
 import io.github.droidkaigi.confsched2022.ui.moleculeComposeState
 import io.github.droidkaigi.confsched2022.zipline.SessionsZipline
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import javax.inject.Inject
 
 @HiltViewModel
 class SessionsViewModel @Inject constructor(

--- a/feature-sessions/src/test/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionScreenRobot.kt
+++ b/feature-sessions/src/test/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionScreenRobot.kt
@@ -18,8 +18,8 @@ import io.github.droidkaigi.confsched2022.model.SessionsRepository
 import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.fake
 import io.github.droidkaigi.confsched2022.testing.RobotTestRule
-import javax.inject.Inject
 import org.amshove.kluent.shouldContain
+import javax.inject.Inject
 
 class SessionScreenRobot @Inject constructor() {
     @Inject lateinit var sessionsRepository: SessionsRepository

--- a/feature-sessions/src/test/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsScreenTest.kt
+++ b/feature-sessions/src/test/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsScreenTest.kt
@@ -3,10 +3,10 @@ package io.github.droidkaigi.confsched2022.feature.sessions
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.droidkaigi.confsched2022.testing.RobotTestRule
-import javax.inject.Inject
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import javax.inject.Inject
 
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest


### PR DESCRIPTION
## Issue
- close #77 

## Overview (Required)
- 1f1c6bf4f406e158db2a1111764289ce3e773e20: Set EditorConfig property `ij_kotlin_imports_layout` for ktlint
- 9a5093652a62da0c96e7914be6702cee5c56f1b0: Apply Spotless again with the updated configuration 

## Details
- The default import order of ktlint is alphabetic order when `android` flag is supplied
  https://github.com/pinterest/ktlint/blob/0.45.2/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt#L40
  - It's different from Android Studio's default settings 👇
    <img width="740" alt="CleanShot 2022-09-06 at 00 50 01@2x" src="https://user-images.githubusercontent.com/12084705/188484740-b9756d9f-a274-4a76-ad84-e65a0afb5def.png">
- We can configure the import order of ktlint by setting `ij_kotlin_imports_layout` property of EditorConfig
  https://pinterest.github.io/ktlint/rules/configuration-ktlint/#import-layouts
- Spotless does not respect the `.editorconfig` settings but we can provide them by using  `editorConfigOverride()` on Gradle script
  https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#ktlint
- So, we can change the import layout settings of ktlint by passing `ij_kotlin_imports_layout` EditorConfig property via `editorConfigOverride()` on Gradle script

## Tests
- I've checked that no diff is generated any more when applying "Optimize Imports" to all files on Android Studio (except for some files in `build-logic`)