### PR TITLE
[feature/#126] Make round corner ripple, when timetable day tabs are clicked

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -31,6 +32,7 @@ internal fun SessionDayTab(
         selected = selected,
         onClick = { onTabClicked(index) },
         modifier = Modifier.height(56.dp).clip(CircleShape)
+            .clipToBounds()
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## Issue
- close #126

## Overview (Required)
- Make round corner ripple, when timetable day tabs are clicked

## Screenshot

<img src="https://user-images.githubusercontent.com/54518925/188486366-3a21a718-d4e1-4012-bdaf-5d1de9648571.mp4" width="300" />
