### PR TITLE
fix layout in session detail screen

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -101,7 +101,9 @@ fun SessionDetailScreen(
         }
     ) {
         Column(
-            modifier = modifier.verticalScroll(rememberScrollState())
+            modifier = modifier
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
         ) {
             SessionDetailSessionInfo(
                 title = item.title.currentLangTitle,
@@ -144,7 +146,7 @@ fun SessionDetailSessionInfo(
     language: String,
     levels: PersistentList<String>,
 
-) {
+    ) {
     Column {
         Text(
             modifier = modifier,

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -145,8 +145,7 @@ fun SessionDetailSessionInfo(
     category: TimetableCategory,
     language: String,
     levels: PersistentList<String>,
-
-    ) {
+) {
     Column {
         Text(
             modifier = modifier,


### PR DESCRIPTION
## Issue
- close #171

## Overview (Required)
- Added horizontal padding to session details

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/31527039/188486829-eea4e158-dd1c-4d8a-a3b4-51b75f3dd28e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/31527039/188486845-29dc1847-8275-4d17-a45b-c92b3a0509dd.png" width="300" />
