### PR TITLE
Scroll up when taps current tab #153

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.feature.sessions
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,12 +14,14 @@ import io.github.droidkaigi.confsched2022.model.TimetableItem
 @Composable
 fun SessionList(
     timetable: Timetable,
+    listState: LazyListState,
     modifier: Modifier = Modifier,
     content: @Composable (TimetableItem, Boolean) -> Unit,
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(32.dp)
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+        state = listState
     ) {
         items(timetable.contents, key = { it.timetableItem.id.value }) {
             content(

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
@@ -14,14 +14,14 @@ import io.github.droidkaigi.confsched2022.model.TimetableItem
 @Composable
 fun SessionList(
     timetable: Timetable,
-    listState: LazyListState,
+    sessionsListListState: LazyListState,
     modifier: Modifier = Modifier,
     content: @Composable (TimetableItem, Boolean) -> Unit,
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(32.dp),
-        state = listState
+        state = sessionsListListState
     ) {
         items(timetable.contents, key = { it.timetableItem.id.value }) {
             content(

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -82,11 +84,13 @@ fun Sessions(
 ) {
     val scheduleState = uiModel.scheduleState
     val pagerState = rememberPagerState()
+    val listStates = DroidKaigi2022Day.values().map { rememberLazyListState() } .toList()
     KaigiScaffold(
         modifier = modifier,
         topBar = {
             SessionsTopBar(
                 pagerState,
+                listStates,
                 scheduleState,
                 onNavigationIconClick,
                 onSearchClick,
@@ -112,6 +116,7 @@ fun Sessions(
                 } else {
                     SessionsList(
                         pagerState = pagerState,
+                        listStates = listStates,
                         scheduleState = scheduleState,
                         days = days,
                         onFavoriteClick = onFavoriteClick
@@ -170,6 +175,7 @@ fun Timetable(
 @Composable
 fun SessionsList(
     pagerState: PagerState,
+    listStates: List<LazyListState>,
     scheduleState: Loaded,
     days: Array<DroidKaigi2022Day>,
     onFavoriteClick: (TimetableItemId, Boolean) -> Unit,
@@ -180,7 +186,7 @@ fun SessionsList(
     ) { dayIndex ->
         val day = days[dayIndex]
         val timetable = scheduleState.schedule.dayToTimetable[day].orEmptyContents()
-        SessionList(timetable) { timetableItem, isFavorited ->
+        SessionList(timetable, listStates[dayIndex]) { timetableItem, isFavorited ->
             SessionListItem(
                 timetableItem = timetableItem,
                 isFavorited = isFavorited,
@@ -194,6 +200,7 @@ fun SessionsList(
 @Composable
 fun SessionsTopBar(
     pagerState: PagerState,
+    listStates: List<LazyListState>,
     scheduleState: ScheduleState,
     onNavigationIconClick: () -> Unit,
     onSearchClick: () -> Unit,
@@ -245,13 +252,17 @@ fun SessionsTopBar(
             ) {
                 val coroutineScope = rememberCoroutineScope()
                 days.forEachIndexed { index, day ->
+                    val selected = pagerState.currentPage == index
                     SessionDayTab(
                         index = index,
                         day = day,
-                        selected = pagerState.currentPage == index,
+                        selected = selected,
                         onTabClicked = {
                             coroutineScope.launch {
                                 pagerState.animateScrollToPage(it)
+                                if (selected) {
+                                    listStates[index].scrollToItem(index = 0)
+                                }
                             }
                         }
                     )

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -84,13 +84,13 @@ fun Sessions(
 ) {
     val scheduleState = uiModel.scheduleState
     val pagerState = rememberPagerState()
-    val listStates = DroidKaigi2022Day.values().map { rememberLazyListState() } .toList()
+    val sessionsListListStates = DroidKaigi2022Day.values().map { rememberLazyListState() }.toList()
     KaigiScaffold(
         modifier = modifier,
         topBar = {
             SessionsTopBar(
                 pagerState,
-                listStates,
+                if (isTimetable) null else sessionsListListStates,
                 scheduleState,
                 onNavigationIconClick,
                 onSearchClick,
@@ -116,7 +116,7 @@ fun Sessions(
                 } else {
                     SessionsList(
                         pagerState = pagerState,
-                        listStates = listStates,
+                        sessionsListListStates = sessionsListListStates,
                         scheduleState = scheduleState,
                         days = days,
                         onFavoriteClick = onFavoriteClick
@@ -175,7 +175,7 @@ fun Timetable(
 @Composable
 fun SessionsList(
     pagerState: PagerState,
-    listStates: List<LazyListState>,
+    sessionsListListStates: List<LazyListState>,
     scheduleState: Loaded,
     days: Array<DroidKaigi2022Day>,
     onFavoriteClick: (TimetableItemId, Boolean) -> Unit,
@@ -186,7 +186,7 @@ fun SessionsList(
     ) { dayIndex ->
         val day = days[dayIndex]
         val timetable = scheduleState.schedule.dayToTimetable[day].orEmptyContents()
-        SessionList(timetable, listStates[dayIndex]) { timetableItem, isFavorited ->
+        SessionList(timetable, sessionsListListStates[dayIndex]) { timetableItem, isFavorited ->
             SessionListItem(
                 timetableItem = timetableItem,
                 isFavorited = isFavorited,
@@ -200,7 +200,7 @@ fun SessionsList(
 @Composable
 fun SessionsTopBar(
     pagerState: PagerState,
-    listStates: List<LazyListState>,
+    sessionsListListStates: List<LazyListState>?,
     scheduleState: ScheduleState,
     onNavigationIconClick: () -> Unit,
     onSearchClick: () -> Unit,
@@ -261,7 +261,9 @@ fun SessionsTopBar(
                             coroutineScope.launch {
                                 pagerState.animateScrollToPage(it)
                                 if (selected) {
-                                    listStates[index].scrollToItem(index = 0)
+                                    sessionsListListStates?.let {
+                                        sessionsListListStates[index].scrollToItem(index = 0)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
 - added a LazyListState to SessionList
 - added multiple LazyListState and pass them to SessionTopBar and SessionList
 - added jump to top on SessionsTopBar when user click selected tab

## Overview (Required)
- Scroll up when taps current tab

## Links
- https://github.com/DroidKaigi/conference-app-2022/issues/153
