### PR TITLE
Fix assets design in session detail

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
@@ -31,7 +33,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -41,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiScaffold
+import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2022.feature.sessions.SessionDetailUiModel.SessionDetailState.Loaded
 import io.github.droidkaigi.confsched2022.model.TimetableAsset
 import io.github.droidkaigi.confsched2022.model.TimetableCategory
@@ -369,28 +374,60 @@ fun SessionDetailAssets(
 
         Spacer(modifier = modifier.padding(16.dp))
 
-        Text(
+        SessionDetailAssetsItem(
             modifier = modifier,
+            painter = painterResource(id = R.drawable.ic_video_cam),
             text = "MOVIE",
-            style = MaterialTheme.typography.bodyMedium,
+            onClick = {},
         )
 
         Spacer(modifier = modifier.padding(8.dp))
 
+        SessionDetailAssetsItem(
+            modifier = modifier,
+            painter = painterResource(id = R.drawable.ic_photo_library),
+            text = "スライド",
+            onClick = {},
+        )
+    }
+}
+
+@Composable
+private fun SessionDetailAssetsItem(
+    modifier: Modifier = Modifier,
+    painter: Painter,
+    text: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .height(36.dp)
+            .clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            painter = painter,
+            contentDescription = null,
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
         Text(
             modifier = modifier,
-            text = "スライド",
+            text = text,
             style = MaterialTheme.typography.bodyMedium,
         )
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun PreviewSessionDetailScreen() {
-    SessionDetailScreen(
-        uiModel = SessionDetailUiModel(
-            Loaded(TimetableItemWithFavorite.fake())
+    KaigiTheme {
+        SessionDetailScreen(
+            uiModel = SessionDetailUiModel(
+                Loaded(TimetableItemWithFavorite.fake())
+            )
         )
-    )
+    }
 }

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -365,6 +365,8 @@ fun SessionDetailAssets(
     modifier: Modifier = Modifier,
     asset: TimetableAsset,
 ) {
+    val uriHandler = LocalUriHandler.current
+
     Column {
         Text(
             modifier = modifier,
@@ -378,7 +380,12 @@ fun SessionDetailAssets(
             modifier = modifier,
             painter = painterResource(id = R.drawable.ic_video_cam),
             text = "MOVIE",
-            onClick = {},
+            onClick = {
+                val videoUrl = asset.videoUrl
+                if (videoUrl != null) {
+                    uriHandler.openUri(videoUrl)
+                }
+            },
         )
 
         Spacer(modifier = modifier.padding(8.dp))
@@ -387,7 +394,12 @@ fun SessionDetailAssets(
             modifier = modifier,
             painter = painterResource(id = R.drawable.ic_photo_library),
             text = "スライド",
-            onClick = {},
+            onClick = {
+                val slideUrl = asset.slideUrl
+                if (slideUrl != null) {
+                    uriHandler.openUri(slideUrl)
+                }
+            },
         )
     }
 }

--- a/feature-sessions/src/main/res/drawable/ic_photo_library.xml
+++ b/feature-sessions/src/main/res/drawable/ic_photo_library.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M6,0H18C19.1,0 20,0.9 20,2V14C20,15.1 19.1,16 18,16H6C4.9,16 4,15.1 4,14V2C4,0.9 4.9,0 6,0ZM18,14V2H6V14H18ZM9.5,9.67L11.19,11.93L13.67,8.83L17,13H7L9.5,9.67ZM0,18V4H2V18H16V20H2C0.9,20 0,19.1 0,18Z"
+      android:fillColor="#E2E3DE"
+      android:fillType="evenOdd"/>
+</vector>

--- a/feature-sessions/src/main/res/drawable/ic_video_cam.xml
+++ b/feature-sessions/src/main/res/drawable/ic_video_cam.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="12dp"
+    android:viewportWidth="18"
+    android:viewportHeight="12">
+  <path
+      android:pathData="M1,0H13C13.55,0 14,0.45 14,1V4.5L18,0.5V11.5L14,7.5V11C14,11.55 13.55,12 13,12H1C0.45,12 0,11.55 0,11V1C0,0.45 0.45,0 1,0ZM12,10V2H2V10H12Z"
+      android:fillColor="#E2E3DE"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
## Issue
- close #161 .

## Overview (Required)
- Add icons
- Open the link on clicking assets if it exists

## Links
- [App design](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/18373318/188623461-d4c821bc-f4cd-4e7d-9056-7df15fc65ce4.png" width="300" /> | <img src="https://user-images.githubusercontent.com/18373318/188623501-bfb714c0-1bf9-42b5-9797-80a06e137908.png" width="300" />
