### PR TITLE
Move currentStartTime into remember block

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -197,8 +197,8 @@ fun SessionsList(
     ) { dayIndex ->
         val day = days[dayIndex]
         val timetable = scheduleState.schedule.dayToTimetable[day].orEmptyContents()
-        var currentStartTime = ""
         val timeHeaderAndTimetableItems = remember(timetable) {
+            var currentStartTime = ""
             val list = mutableListOf<Pair<DurationTime?, TimetableItemWithFavorite>>()
             timetable.contents.forEachIndexed { index, timetableItemWithFavorite ->
                 val startLocalDateTime = timetableItemWithFavorite.timetableItem.startsAt


### PR DESCRIPTION
## Issue
- close [227](https://github.com/DroidKaigi/conference-app-2022/issues/227)

## Overview (Required)
- Just move into remember block
