### PR TITLE
Add BuildKonfig to support production api url

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.hiltGradlePlugin)
     implementation(libs.moleculeGradlePlugin)
     implementation(libs.kotlinSerializationPlugin)
+    implementation(libs.buildkonfigPlugin)
     implementation(libs.firebasePlugin)
 }
 
@@ -82,6 +83,10 @@ gradlePlugin {
         register("kotlinMppKotlinSerialization") {
             id = "droidkaigi.primitive.kmp.serialization"
             implementationClass = "io.github.droidkaigi.confsched2022.primitive.KotlinSerializationPlugin"
+        }
+        register("kotlinMppBuildKonfig") {
+            id = "droidkaigi.primitive.kmp.buildkonfig"
+            implementationClass = "io.github.droidkaigi.confsched2022.primitive.KmpBuildKonfigPlugin"
         }
         register("molecule") {
             id = "droidkaigi.primitive.molecule"

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/KmpBuildKonfigPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/KmpBuildKonfigPlugin.kt
@@ -1,0 +1,15 @@
+package io.github.droidkaigi.confsched2022.primitive
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+@Suppress("unused")
+class KmpBuildKonfigPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.codingfeline.buildkonfig")
+            }
+        }
+    }
+}

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -1,7 +1,10 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
+
 plugins {
     id("droidkaigi.convention.kmp")
     id("droidkaigi.primitive.kmp.android.hilt")
     id("droidkaigi.primitive.kmp.serialization")
+    id("droidkaigi.primitive.kmp.buildkonfig")
 }
 
 android.namespace = "io.github.droidkaigi.confsched2022.core.data"
@@ -36,5 +39,16 @@ kotlin {
                 implementation(libs.koin)
             }
         }
+    }
+}
+
+buildkonfig {
+    packageName = "io.github.droidkaigi.confsched2022"
+
+    defaultConfigs {
+        buildConfigField(STRING, "apiUrl", "https://ssot-api-staging.an.r.appspot.com")
+    }
+    defaultConfigs("prod") {
+        buildConfigField(STRING, "apiUrl", "https://ssot-api.droidkaigi.jp")
     }
 }

--- a/core-data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/auth/AuthApi.kt
+++ b/core-data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/auth/AuthApi.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2022.data.auth
 
+import io.github.droidkaigi.confsched2022.BuildKonfig
 import io.github.droidkaigi.confsched2022.data.SettingsDatastore
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.ResponseException
@@ -40,7 +41,7 @@ class AuthApi(
         runCatching {
             // Use httpClient for bypass auth process
             httpClient
-                .post("https://ssot-api-staging.an.r.appspot.com/accounts") {
+                .post("${BuildKonfig.apiUrl}/accounts") {
                     header(HttpHeaders.Authorization, "Bearer $createdIdToken")
                     contentType(ContentType.Application.Json)
                     setBody("{}")

--- a/core-data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/contributors/ContributorsApi.kt
+++ b/core-data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/contributors/ContributorsApi.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2022.data.contributors
 
+import io.github.droidkaigi.confsched2022.BuildKonfig
 import io.github.droidkaigi.confsched2022.data.NetworkService
 import io.github.droidkaigi.confsched2022.data.contributors.response.ContributorsResponse
 import io.github.droidkaigi.confsched2022.model.Contributor
@@ -11,7 +12,7 @@ class ContributorsApi(
 ) {
     suspend fun contributors(): PersistentList<Contributor> {
         return networkService.get<ContributorsResponse>(
-            url = "https://ssot-api-staging.an.r.appspot.com/events/droidkaigi2022/contributors",
+            url = "${BuildKonfig.apiUrl}/events/droidkaigi2022/contributors",
             needAuth = true
         ).toContributorList()
     }

--- a/core-data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/sessions/SessionsApi.kt
+++ b/core-data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/sessions/SessionsApi.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2022.data.sessions
 
+import io.github.droidkaigi.confsched2022.BuildKonfig
 import io.github.droidkaigi.confsched2022.data.NetworkService
 import io.github.droidkaigi.confsched2022.data.sessions.response.LocaledResponse
 import io.github.droidkaigi.confsched2022.data.sessions.response.SessionAllResponse
@@ -26,7 +27,7 @@ class SessionsApi(
     suspend fun timetable(): Timetable {
         return networkService
             .get<SessionAllResponse>(
-                url = "https://ssot-api-staging.an.r.appspot.com/events/droidkaigi2022/timetable",
+                url = "${BuildKonfig.apiUrl}/events/droidkaigi2022/timetable",
                 needAuth = true
             )
             .toTimetable()

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,10 @@ org.gradle.caching=true
 org.gradle.parallel=true
 
 kotlin.js.compiler=ir
+
+# Kotlin Multiplatform Project does not support product flavor.
+# Kotlin/Native part of the project has release/debug distinction, but it's not global.
+# So to mimick product flavor capability of Android, we need to provide additional property
+# in order to determine flavors.
+# https://github.com/yshrsmz/BuildKonfig#product-flavor
+buildkonfig.flavor=dev

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 androidGradlePlugin = "7.4.0-alpha10"
 kotlin = "1.7.10"
 molecule = "0.4.0"
+buildkonfig = "0.13.3"
 
 androidxCore = "1.8.0"
 androidDesugarJdkLibs = "1.2.2"
@@ -52,6 +53,7 @@ hiltGradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-pl
 moleculeGradlePlugin = { module = "app.cash.molecule:molecule-gradle-plugin", version.ref = "molecule" }
 composeCompiler = { group = "androidx.compose.compiler", name = "compiler", version.ref = "composeCompiler" }
 kotlinSerializationPlugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
+buildkonfigPlugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "buildkonfig" }
 ziplineKotlinPlugin = { module = "app.cash.zipline:zipline-kotlin-plugin", version.ref = "zipline" }
 ziplineGradlePlugin = { module = "app.cash.zipline:zipline-gradle-plugin", version.ref = "zipline" }
 firebasePlugin = { module = "com.google.gms:google-services", version.ref = "firebasePlugin" }


### PR DESCRIPTION
## Issue
- close #232 

## Overview (Required)
- Kotlin Multiplatform Project does not support product flavor. So we need to provide additional property in order to determine flavors.

Specify default flavor in root `gradle.properties`
```
buildkonfig.flavor=dev
buildkonfig.flavor=prod
```
and also we can pass value via CLI `$ ./gradlew build -Pbuildkonfig.flavor=prod`


## Links
- https://github.com/yshrsmz/BuildKonfig#product-flavor