### PR TITLE
:wrench: Fix Fixed a bug in session details

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -157,7 +157,7 @@ fun SessionDetailScreen(
             SessionDetailSessionInfo(
                 title = item.title.currentLangTitle,
                 startsAt = item.startsAt,
-                endsAt = item.startsAt,
+                endsAt = item.endsAt,
                 room = item.room,
                 category = item.category,
                 language = item.language,


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- The start time was displayed in the end time, which was corrected.

## Links
- Nothing.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13657682/188781859-88d3bb8b-53db-457f-8f39-82681320e6cc.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13657682/188781851-fec398f6-d68c-4ca1-9b5f-45b7a58db615.png" width="300" />