### PR TITLE
:wrench: Fixed display of multiple speakers.

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -327,7 +327,9 @@ fun SessionDetailSpeakers(
 
         speakers.forEach { speaker ->
             if (speaker.iconUrl.isNotEmpty()) {
-                Row {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     AsyncImage(
                         model = speaker.iconUrl,
                         modifier = Modifier
@@ -347,6 +349,9 @@ fun SessionDetailSpeakers(
                         style = MaterialTheme.typography.bodyLarge,
                     )
                 }
+                Spacer(
+                    modifier = modifier.padding(vertical = 12.dp)
+                )
             }
         }
 


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- As the title says.
  - Also, speaker names are now centered with respect to the icon.

## Links
- Nothing.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13657682/188784785-d2132448-a4e7-4235-bdb4-e0d8d55cba73.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13657682/188784782-8dacfb6d-0c05-4ccc-9224-08a7ff58b6f6.png" width="300" />
