### PR TITLE
Remove unnecessary NavigationDrawer's navigation stack

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -69,7 +69,10 @@ fun KaigiApp(
                     DrawerSheet(
                         selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem,
                         onClickDrawerItem = { drawerItem ->
-                            kaigiAppScaffoldState.navigate(drawerItem, kaigiAppScaffoldState.selectedDrawerItem!!)
+                            kaigiAppScaffoldState.navigate(
+                                drawerItem = drawerItem,
+                                selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem!!
+                            )
                         }
                     )
                 }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -69,7 +69,7 @@ fun KaigiApp(
                     DrawerSheet(
                         selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem,
                         onClickDrawerItem = { drawerItem ->
-                            kaigiAppScaffoldState.navigate(drawerItem)
+                            kaigiAppScaffoldState.navigate(drawerItem, kaigiAppScaffoldState.selectedDrawerItem!!)
                         }
                     )
                 }
@@ -134,8 +134,12 @@ class KaigiAppScaffoldState @OptIn(ExperimentalMaterial3Api::class) constructor(
     val navController: NavHostController,
     val drawerState: DrawerState,
 ) {
-    fun navigate(drawerItem: DrawerItem) {
-        navController.navigate(drawerItem.navRoute)
+    fun navigate(drawerItem: DrawerItem, selectedDrawerItem: DrawerItem) {
+        navController.navigate(drawerItem.navRoute) {
+            popUpTo(selectedDrawerItem.navRoute) {
+                inclusive = true
+            }
+        }
         coroutineScope.launch {
             drawerState.close()
         }


### PR DESCRIPTION
## Issue
- Does not contain any currently existing issues

## Overview (Required)
- As the title says, before this, if we visited different drawerItems multiple times, we would create a lot of back stacks, which would cause difficulties if we wanted to use the system return button to return to the desktop

## Screenshot

before:

https://user-images.githubusercontent.com/31311826/188820445-e26dc120-0d7c-456c-acd6-54b89c2a0fe1.mp4

after:

https://user-images.githubusercontent.com/31311826/188820426-654a5d0c-65fe-40ea-8096-f5d8b6550a59.mp4