### PR TITLE
Improve build performance for Kotlin Native

### DIFF
--- a/.github/workflows/iOSBuild.yml
+++ b/.github/workflows/iOSBuild.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build KMM Module
-        run: ./gradlew appioscombined:assembleXCFramework
+        run: ./gradlew appioscombined:assembleAppioscombinedReleaseXCFramework
       - name: Upload xcframework artifact
         uses: actions/upload-artifact@v3
         with:
           name: appioscombined.xcframework
-          path: app-ios-combined/build/XCFrameworks/debug/appioscombined.xcframework/
+          path: app-ios-combined/build/XCFrameworks/release/appioscombined.xcframework/

--- a/app-ios-combined/build.gradle.kts
+++ b/app-ios-combined/build.gradle.kts
@@ -16,7 +16,8 @@ kotlin {
         )
         val xcFrameworkName = "appioscombined"
         val xcf = XCFramework(xcFrameworkName)
-        val sourceSets = listOf(iosX64(), iosArm64(), iosSimulatorArm64())
+        val isCI = System.getenv()["CI"]?.toBoolean() ?: false
+        val sourceSets = if (isCI) listOf(iosX64()) else listOf(iosX64(), iosArm64(), iosSimulatorArm64())
         sourceSets.forEach {
             it.binaries.framework {
                 baseName = xcFrameworkName

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/KmpIosPlugin.kt
@@ -2,31 +2,32 @@ package io.github.droidkaigi.confsched2022.primitive
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 @Suppress("unused")
 class KmpIosPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             kotlin {
-                iosX64()
-                iosArm64()
-                iosSimulatorArm64()
+                val isCI = System.getenv()["CI"]?.toBoolean() ?: false
                 val iosMain = sourceSets.create("iosMain") {
                     dependsOn(sourceSets.getByName("commonMain"))
                 }
+                iosX64()
                 sourceSets.getByName("iosX64Main") {
                     dependsOn(iosMain)
                 }
-                sourceSets.getByName("iosArm64Main") {
-                    dependsOn(iosMain)
-                }
-                sourceSets.getByName("iosSimulatorArm64Main") {
-                    dependsOn(iosMain)
+                // make build speed faster on CI
+                if (!isCI) {
+                    iosArm64()
+                    iosSimulatorArm64()
+                    sourceSets.getByName("iosArm64Main") {
+                        dependsOn(iosMain)
+                    }
+                    sourceSets.getByName("iosSimulatorArm64Main") {
+                        dependsOn(iosMain)
+                    }
                 }
                 targets.withType<KotlinNativeTarget>().configureEach {
                     binaries.all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Issue
- nothings

## Overview (Required)
- I inserted check for build environment
- K/N spends much time for multiple architecture building
- On this app, CI runs on X64 mac and non need to build arm and arm simulator on this time
- GitHub Actions provides [default environment](https://docs.github.com/ja/actions/learn-github-actions/environment-variables#default-environment-variables) to check ci env, so inserted

## Links
- https://github.com/DroidKaigi/conference-app-2022/pull/257

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
