### PR TITLE
Set weight to the height of the text in TimetableItem

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -24,8 +24,7 @@ import io.github.droidkaigi.confsched2022.model.TimetableItem
 fun TimetableItem(
     timetableItem: TimetableItem,
     isFavorited: Boolean,
-    modifier: Modifier = Modifier,
-    maxTitleLines: Int = 4
+    modifier: Modifier = Modifier
 ) {
     val roomName = timetableItem.room.name
     val roomColor = TimetableItemColor.colorOfRoomName(enName = roomName.enTitle)
@@ -47,9 +46,9 @@ fun TimetableItem(
             color = Color.White,
             modifier = Modifier
                 .padding(bottom = 8.dp)
+                .weight(1f)
                 .fillMaxWidth(),
             overflow = TextOverflow.Ellipsis,
-            maxLines = maxTitleLines,
             style = MaterialTheme.typography.titleMedium.copy(
                 letterSpacing = 0.1.sp
             )

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -46,7 +46,7 @@ fun TimetableItem(
             color = Color.White,
             modifier = Modifier
                 .padding(bottom = 8.dp)
-                .weight(1f)
+                .weight(weight = 1f, fill = false)
                 .fillMaxWidth(),
             overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.titleMedium.copy(


### PR DESCRIPTION
## Issue
- close #91 

## Overview (Required)
- weight of TimetableItem-Text and remove of maxlines setting.
- maxLines setting does not work well for changed the device font size.
  - The maxline of the text is automatically varied to match the display area of the Text.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1332886/188884933-ca6ba1f6-0758-477f-9d31-02892909f763.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1332886/188899685-3bb50fbf-16f3-4580-a29e-327644a5350b.png" width="300" />
<img src="https://user-images.githubusercontent.com/1332886/188885702-6d30d5ae-aed4-45f4-9ac9-5f50b5fc9e9a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1332886/188899929-1fbe3306-9fee-47da-a94b-d06e3060f80a.png" width="300" />