### PR TITLE
Display persistent navigation drawer when window width is "expanded"

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2022
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Android
@@ -19,6 +20,7 @@ import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.PermanentDrawerSheet
 import androidx.compose.material3.PermanentNavigationDrawer
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
@@ -71,8 +73,8 @@ fun KaigiApp(
             KaigiAppDrawer(
                 kaigiAppScaffoldState = kaigiAppScaffoldState,
                 showPermanently = usePersistentNavigationDrawer,
-                drawerSheet = {
-                    DrawerSheet(
+                drawerSheetContent = {
+                    DrawerSheetContent(
                         selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem,
                         onClickDrawerItem = { drawerItem ->
                             kaigiAppScaffoldState.navigate(drawerItem)
@@ -129,19 +131,19 @@ fun rememberKaigiAppScaffoldState(
 fun KaigiAppDrawer(
     kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState(),
     showPermanently: Boolean,
-    drawerSheet: @Composable () -> Unit,
+    drawerSheetContent: @Composable ColumnScope.() -> Unit,
     content: @Composable () -> Unit
 ) {
     if (showPermanently) {
         PermanentNavigationDrawer(
-            drawerContent = { drawerSheet() },
+            drawerContent = { PermanentDrawerSheet { drawerSheetContent() } },
         ) {
             content()
         }
     } else {
         ModalNavigationDrawer(
             drawerState = kaigiAppScaffoldState.drawerState,
-            drawerContent = { drawerSheet() },
+            drawerContent = { ModalDrawerSheet { drawerSheetContent() } },
         ) {
             content()
         }
@@ -215,36 +217,34 @@ enum class DrawerItem(val titleResId: Int, val icon: ImageVector, val navRoute: 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DrawerSheet(
+fun ColumnScope.DrawerSheetContent(
     selectedDrawerItem: DrawerItem?,
     onClickDrawerItem: (DrawerItem) -> Unit
 ) {
-    ModalDrawerSheet {
-        Image(
-            painter = painterResource(id = R.drawable.img_navigation_drawer_lookup),
-            contentDescription = null,
-            modifier = Modifier.padding(12.dp, 12.dp, 12.dp, 0.dp)
+    Image(
+        painter = painterResource(id = R.drawable.img_navigation_drawer_lookup),
+        contentDescription = null,
+        modifier = Modifier.padding(12.dp, 12.dp, 12.dp, 0.dp)
+    )
+    DrawerItem.values().forEach { drawerItem ->
+        NavigationDrawerItem(
+            icon = {
+                Icon(imageVector = drawerItem.icon, contentDescription = null)
+            },
+            label = {
+                Text(stringResource(drawerItem.titleResId))
+            },
+            selected = drawerItem == selectedDrawerItem,
+            onClick = {
+                onClickDrawerItem(drawerItem)
+            },
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
         )
-        DrawerItem.values().forEach { drawerItem ->
-            NavigationDrawerItem(
-                icon = {
-                    Icon(imageVector = drawerItem.icon, contentDescription = null)
-                },
-                label = {
-                    Text(stringResource(drawerItem.titleResId))
-                },
-                selected = drawerItem == selectedDrawerItem,
-                onClick = {
-                    onClickDrawerItem(drawerItem)
-                },
-                modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+        if (drawerItem == DrawerItem.Sessions || drawerItem == DrawerItem.Map) {
+            Divider(
+                thickness = 1.dp,
+                modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp)
             )
-            if (drawerItem == DrawerItem.Sessions || drawerItem == DrawerItem.Map) {
-                Divider(
-                    thickness = 1.dp,
-                    modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp)
-                )
-            }
         }
     }
 }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -19,9 +19,11 @@ import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.PermanentNavigationDrawer
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
@@ -57,7 +59,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KaigiApp(
-    calculateWindowSizeClass: WindowSizeClass,
+    windowSizeClass: WindowSizeClass,
     kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState()
 ) {
     KaigiTheme {
@@ -65,8 +67,10 @@ fun KaigiApp(
             LocalShareManager provides AndroidShareManager(LocalContext.current),
             LocalCalendarRegistration provides AndroidCalendarRegistration(LocalContext.current),
         ) {
+            val usePersistentNavigationDrawer = windowSizeClass.usePersistentNavigationDrawer
             KaigiAppDrawer(
                 kaigiAppScaffoldState = kaigiAppScaffoldState,
+                showPermanently = usePersistentNavigationDrawer,
                 drawerSheet = {
                     DrawerSheet(
                         selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem,
@@ -96,6 +100,14 @@ fun KaigiApp(
     }
 }
 
+private val WindowSizeClass.usePersistentNavigationDrawer: Boolean
+    get() = when (widthSizeClass) {
+        WindowWidthSizeClass.Compact -> false
+        WindowWidthSizeClass.Medium -> false
+        WindowWidthSizeClass.Expanded -> true
+        else -> false
+    }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberKaigiAppScaffoldState(
@@ -116,18 +128,23 @@ fun rememberKaigiAppScaffoldState(
 @Composable
 fun KaigiAppDrawer(
     kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState(),
+    showPermanently: Boolean,
     drawerSheet: @Composable () -> Unit,
     content: @Composable () -> Unit
 ) {
-    val coroutineScope = rememberCoroutineScope()
-
-    ModalNavigationDrawer(
-        drawerState = kaigiAppScaffoldState.drawerState,
-        drawerContent = {
-            drawerSheet()
+    if (showPermanently) {
+        PermanentNavigationDrawer(
+            drawerContent = { drawerSheet() },
+        ) {
+            content()
         }
-    ) {
-        content()
+    } else {
+        ModalNavigationDrawer(
+            drawerState = kaigiAppScaffoldState.drawerState,
+            drawerContent = { drawerSheet() },
+        ) {
+            content()
+        }
     }
 }
 

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -87,14 +87,22 @@ fun KaigiApp(
                     navController = kaigiAppScaffoldState.navController,
                     startDestination = SessionsNavGraph.sessionRoute,
                 ) {
+                    val showNavigationIcon = !usePersistentNavigationDrawer
                     sessionsNavGraph(
+                        showNavigationIcon,
                         kaigiAppScaffoldState::onNavigationClick,
                         kaigiAppScaffoldState::onBackIconClick,
                         kaigiAppScaffoldState::onTimeTableClick,
                         kaigiAppScaffoldState::onNavigateFloorMapClick,
                     )
-                    contributorsNavGraph(kaigiAppScaffoldState::onNavigationClick)
-                    aboutNavGraph(kaigiAppScaffoldState::onNavigationClick)
+                    contributorsNavGraph(
+                        showNavigationIcon,
+                        kaigiAppScaffoldState::onNavigationClick,
+                    )
+                    aboutNavGraph(
+                        showNavigationIcon,
+                        kaigiAppScaffoldState::onNavigationClick,
+                    )
                     mapGraph()
                 }
             }

--- a/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/theme/KaigiTopAppBar.kt
+++ b/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/theme/KaigiTopAppBar.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KaigiTopAppBar(
+    showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     modifier: Modifier = Modifier,
     elevation: Dp = 0.dp,
@@ -41,10 +42,12 @@ fun KaigiTopAppBar(
             }
         },
         navigationIcon = {
-            IconButton(
-                onClick = onNavigationIconClick
-            ) {
-                Icon(imageVector = Icons.Default.Menu, "menu")
+            if (showNavigationIcon) {
+                IconButton(
+                    onClick = onNavigationIconClick
+                ) {
+                    Icon(imageVector = Icons.Default.Menu, "menu")
+                }
             }
         },
         colors = TopAppBarDefaults.smallTopAppBarColors(

--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
@@ -51,14 +51,16 @@ import io.github.droidkaigi.confsched2022.feature.about.R.string
 @Composable
 fun AboutScreenRoot(
     modifier: Modifier = Modifier,
+    showNavigationIcon: Boolean = true,
     onNavigationIconClick: () -> Unit = {},
     versionName: String? = versionName(LocalContext.current)
 ) {
-    About(onNavigationIconClick, modifier, versionName)
+    About(showNavigationIcon, onNavigationIconClick, modifier, versionName)
 }
 
 @Composable
 fun About(
+    showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     modifier: Modifier = Modifier,
     versionName: String?
@@ -66,6 +68,7 @@ fun About(
     KaigiScaffold(
         topBar = {
             KaigiTopAppBar(
+                showNavigationIcon = showNavigationIcon,
                 onNavigationIconClick = onNavigationIconClick,
                 title = {
                     Text(

--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/AboutNavGraph.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/AboutNavGraph.kt
@@ -3,9 +3,15 @@ package io.github.droidkaigi.confsched2022.feature.about
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 
-fun NavGraphBuilder.aboutNavGraph(onNavigationIconClick: () -> Unit) {
+fun NavGraphBuilder.aboutNavGraph(
+    showNavigationIcon: Boolean,
+    onNavigationIconClick: () -> Unit,
+) {
     composable(route = AboutNavGraph.aboutRoute) {
-        AboutScreenRoot(onNavigationIconClick = onNavigationIconClick)
+        AboutScreenRoot(
+            showNavigationIcon = showNavigationIcon,
+            onNavigationIconClick = onNavigationIconClick,
+        )
     }
 }
 

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -41,22 +41,25 @@ import io.github.droidkaigi.confsched2022.feature.contributors.ContributorsUiMod
 @Composable
 fun ContributorsScreenRoot(
     modifier: Modifier = Modifier,
+    showNavigationIcon: Boolean = true,
     onNavigationIconClick: () -> Unit = {}
 ) {
     val viewModel = hiltViewModel<ContributorsViewModel>()
     val uiModel by viewModel.uiModel
-    Contributors(uiModel, onNavigationIconClick, modifier)
+    Contributors(uiModel, showNavigationIcon, onNavigationIconClick, modifier)
 }
 
 @Composable
 fun Contributors(
     uiModel: ContributorsUiModel,
+    showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     KaigiScaffold(
         topBar = {
             KaigiTopAppBar(
+                showNavigationIcon = showNavigationIcon,
                 onNavigationIconClick = onNavigationIconClick,
                 title = {
                     Text(

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsNavGraph.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsNavGraph.kt
@@ -3,9 +3,15 @@ package io.github.droidkaigi.confsched2022.feature.contributors
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 
-fun NavGraphBuilder.contributorsNavGraph(onNavigationIconClick: () -> Unit) {
+fun NavGraphBuilder.contributorsNavGraph(
+    showNavigationIcon: Boolean,
+    onNavigationIconClick: () -> Unit,
+) {
     composable(route = ContributorsNavGraph.contributorsRoute) {
-        ContributorsScreenRoot(onNavigationIconClick = onNavigationIconClick)
+        ContributorsScreenRoot(
+            showNavigationIcon = showNavigationIcon,
+            onNavigationIconClick = onNavigationIconClick,
+        )
     }
 }
 

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -61,6 +61,7 @@ import io.github.droidkaigi.confsched2022.core.designsystem.R as CoreR
 @Composable
 fun SessionsScreenRoot(
     modifier: Modifier = Modifier,
+    showNavigationIcon: Boolean = true,
     onNavigationIconClick: () -> Unit = {},
     onSearchClicked: () -> Unit = {},
     onTimetableClick: (TimetableItemId) -> Unit = {},
@@ -77,6 +78,7 @@ fun SessionsScreenRoot(
         onFavoriteClick = { timetableItemId, isFavorite ->
             viewModel.onFavoriteToggle(timetableItemId, isFavorite)
         },
+        showNavigationIcon = showNavigationIcon,
         onNavigationIconClick = onNavigationIconClick,
         onSearchClick = onSearchClicked,
         onToggleTimetableClick = { isTimetable = !isTimetable },
@@ -89,6 +91,7 @@ fun Sessions(
     uiModel: SessionsUiModel,
     isTimetable: Boolean,
     modifier: Modifier = Modifier,
+    showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     onTimetableClick: (timetableItemId: TimetableItemId) -> Unit,
     onFavoriteClick: (TimetableItemId, Boolean) -> Unit,
@@ -105,6 +108,7 @@ fun Sessions(
                 pagerState,
                 if (isTimetable) null else sessionsListListStates,
                 scheduleState,
+                showNavigationIcon,
                 onNavigationIconClick,
                 onSearchClick,
                 onToggleTimetableClick
@@ -278,6 +282,7 @@ fun SessionsTopBar(
     pagerState: PagerState,
     sessionsListListStates: List<LazyListState>?,
     scheduleState: ScheduleState,
+    showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     onSearchClick: () -> Unit,
     onToggleTimetableClick: () -> Unit,
@@ -287,6 +292,7 @@ fun SessionsTopBar(
         modifier = modifier
     ) {
         KaigiTopAppBar(
+            showNavigationIcon = showNavigationIcon,
             onNavigationIconClick = onNavigationIconClick,
             elevation = 2.dp,
             title = {
@@ -385,6 +391,7 @@ fun SessionsTimetablePreview() {
                 scheduleState = Loaded(DroidKaigiSchedule.fake()),
                 isFilterOn = false
             ),
+            showNavigationIcon = true,
             onNavigationIconClick = {},
             onTimetableClick = {},
             onFavoriteClick = { _, _ -> },
@@ -404,6 +411,7 @@ fun SessionsSessionListPreview() {
                 scheduleState = Loaded(DroidKaigiSchedule.fake()),
                 isFilterOn = false
             ),
+            showNavigationIcon = true,
             onNavigationIconClick = {},
             onTimetableClick = {},
             onFavoriteClick = { _, _ -> },

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
@@ -7,6 +7,7 @@ import androidx.navigation.navArgument
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
 
 fun NavGraphBuilder.sessionsNavGraph(
+    showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     onBackIconClick: () -> Unit,
     onTimetableClick: (TimetableItemId) -> Unit,
@@ -14,6 +15,7 @@ fun NavGraphBuilder.sessionsNavGraph(
 ) {
     composable(route = SessionsNavGraph.sessionRoute) {
         SessionsScreenRoot(
+            showNavigationIcon = showNavigationIcon,
             onNavigationIconClick = onNavigationIconClick,
             onSearchClicked = { /*TODO: Implement later*/ },
             onTimetableClick = onTimetableClick,


### PR DESCRIPTION
## Issue
- close #182

## Overview (Required)
- Show persistent navigation drawer instead of modal navigation drawer if window width is classified as ["Expanded" (>= 840dp)](https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes#window_size_classes)

## Details
- The class of window size is already calculated by using [`calculateWindowSizeClass()`](https://developer.android.com/reference/kotlin/androidx/compose/material3/windowsizeclass/package-summary#calculateWindowSizeClass(android.app.Activity)) in `MainActivity` and it's passed to `KaigiApp`
- a367deb84ec5edbd2a2869517433f21ec406b35f: In `KaigiAppDrawer`, use [`PermanentNavigationDrawer`](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#PermanentNavigationDrawer(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0)) instead of [`ModalNavigationDrawer`](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#ModalNavigationDrawer(kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.material3.DrawerState,kotlin.Boolean,androidx.compose.ui.graphics.Color,kotlin.Function0)) to show persistent navigation drawer if [`WindowSizeClass.widthSizeClass`](https://developer.android.com/reference/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass#widthSizeClass()) is [`WindowWidthSizeClass.Expanded`](https://developer.android.com/reference/kotlin/androidx/compose/material3/windowsizeclass/WindowWidthSizeClass#Expanded())
- 90c8dd9c2bccf2ff7f65bbe21211f1f310bba61a: When using `PermanentNavigationDrawer`, use [`PermanentDrawerSheet`](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#PermanentDrawerSheet(androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Shape,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.Dp,androidx.compose.foundation.layout.WindowInsets,kotlin.Function1)) instead of [`ModalDrawerSheet`](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#ModalDrawerSheet(androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Shape,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.Dp,androidx.compose.foundation.layout.WindowInsets,kotlin.Function1)) as the wrapper of drawer sheet content
  - `ModalDrawerSheet` has rounded corners and they don't fit with the appearance of `PermanentNavigationDrawer`
    <img width="480" src="https://user-images.githubusercontent.com/12084705/188929649-682c28a0-c1dc-4e4f-8908-b7e1e0f3b047.png">
- de2ea60b2ad6c30c451f11dd32acc84d25c3e28b: Hide navigation icon in each screen when showing persistent navigation drawer
  <img width="480" src="https://user-images.githubusercontent.com/12084705/188934520-ad83e0b4-84a4-4c32-814f-63c461096bce.png">
  - Add `showNavigationIcon` argument to `KaigiTopAppBar`
  - Decide the visibility of navigation icon in `KaigiApp` and pass the flag to each `XxxScreenRoot`

## Screenshot

### Compact width

|Before|After|
|---|---|
|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929821-3a529ee1-f5a8-49ea-a76e-ea7fbe9774cd.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929826-b2edfa89-3a22-481c-9c81-ec6abe3a9960.png">|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929911-7c63efd5-f204-4e1b-bd51-1665e772f2a0.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929914-7ae063a2-eae8-4812-88c1-afff018cebb3.png">|
|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929827-61d22d38-5e96-4f3f-9c04-3573af395e47.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929832-f99a8a68-5637-45b6-adba-41eeef3e02fd.png">|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929917-e2a672a7-6a8b-495c-ba0e-f1bccb31b5e6.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929919-fb1ecb39-30cb-4d6a-81f0-c8ff37f17e6d.png">|
|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929834-7dd6b516-4583-4135-9396-eb5f92aa2087.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929837-1fd8dcb0-ea95-41ef-b8b9-4edec3145511.png">|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929922-13ecdb7d-273e-4c93-953f-486c7d16744b.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929924-64b493f6-dfea-4028-a4c7-e7ebcb4c1985.png">|


### Medium width

|Before|After|
|---|---|
|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929840-fac10961-d823-427a-876b-21caca538805.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929841-d1567703-b357-4183-aaff-a36f43cdbfa3.png">|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929925-ab39a58d-8ff2-47ea-963a-e4cf7cb9ae4a.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929927-6c2471a5-285f-4607-abd5-2cc2cc1c14cf.png">|
|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929844-977492c7-2da3-47f7-b1f4-a70e00a9de2f.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929847-d38944bd-b347-4ed6-805c-4982c5adfe5e.png">|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929929-944c1e8e-a1f9-4025-8768-ab1abb6c1fc3.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929932-cda150cc-3011-4e62-ad50-f9570ca67bdd.png">|
|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929852-9079167b-a7ea-4283-8e17-046696757cc8.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929856-f7565069-c9a3-4c98-83d0-2d208e38dcf7.png">|<img width="160" src="https://user-images.githubusercontent.com/12084705/188929934-2750e0f0-d01a-4afc-84ff-413465daeabf.png"> <img width="160" src="https://user-images.githubusercontent.com/12084705/188929935-1732d353-5885-42a7-bfb1-e6d9b5959df8.png">|

### Expanded width

|Before|After|
|---|---|
|<img width="480" src="https://user-images.githubusercontent.com/12084705/188929858-d462d7d6-8022-4985-a311-cdb05446c977.png"><br><img width="480" src="https://user-images.githubusercontent.com/12084705/188929861-38598172-2eaa-4f2b-9f70-b6ce104c4a81.png">|<img width="480" src="https://user-images.githubusercontent.com/12084705/188929936-941a6189-0f6a-49a1-bbfa-27c14ef5efbe.png">|
|<img width="480" src="https://user-images.githubusercontent.com/12084705/188929864-0f2fbf7b-7341-493b-8273-ad4a13f466fa.png"><br><img width="480" src="https://user-images.githubusercontent.com/12084705/188929869-f91b7b82-e885-4a28-8deb-a21ef9646001.png">|<img width="480" src="https://user-images.githubusercontent.com/12084705/188929941-05e54ea7-06c3-46cc-bb18-380f724bfb32.png">|
|<img width="480" src="https://user-images.githubusercontent.com/12084705/188929872-12f78413-6c0e-4f57-8663-cc6e9fcf65b1.png"><br><img width="480" src="https://user-images.githubusercontent.com/12084705/188929875-2368b9c1-9ee2-47e4-b1dd-b61b0b838c48.png">|<img width="480" src="https://user-images.githubusercontent.com/12084705/188929943-ba3af2a0-6520-45c9-b8d9-5332d6118b7f.png">|