### PR TITLE
Make common value for timetable layout size

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
@@ -70,11 +70,11 @@ fun Rooms(
     val visibleItemLayouts by remember(roomsScreen) { roomsScreen.visibleItemLayouts }
 
     val lineColor = MaterialTheme.colorScheme.surfaceVariant
-    val linePxSize = with(timetableState.density) { timeTableLineStrokeSize.toPx() }
+    val linePxSize = with(timetableState.density) { TimetableSizes.lineStrokeSize.toPx() }
 
     LazyLayout(
         modifier = modifier
-            .height(height = roomHeaderHeight)
+            .height(height = RoomsSizes.headerHeight)
             .clipToBounds()
             .drawBehind {
                 roomsScreen.verticalLines.value.forEach {
@@ -153,8 +153,8 @@ private data class RoomItemLayout(
     val density: Density,
     val index: Int,
 ) {
-    val width = with(density) { roomHeaderWidth.roundToPx() }
-    val height = with(density) { roomHeaderHeight.roundToPx() }
+    val width = with(density) { TimetableSizes.columnWidth.roundToPx() }
+    val height = with(density) { RoomsSizes.headerHeight.roundToPx() }
     val left = index * width
     val top = 0
     val right = left + width
@@ -190,7 +190,7 @@ private class RoomScreen(
         }
 
     val verticalLines = derivedStateOf {
-        val width = with(density) { roomHeaderWidth.toPx() }
+        val width = with(density) { TimetableSizes.columnWidth.toPx() }
         val rooms = roomsLayout.rooms
         (0..rooms.lastIndex).map {
             scrollState.scrollX + width * it
@@ -227,6 +227,6 @@ private fun itemProvider(
     }
 }
 
-private val timeTableLineStrokeSize = 1.dp
-private val roomHeaderWidth = 192.dp
-private val roomHeaderHeight = 48.dp
+private object RoomsSizes {
+    val headerHeight = 48.dp
+}

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -84,7 +84,7 @@ fun Timetable(
     }
     val visibleItemLayouts by remember(timetableScreen) { timetableScreen.visibleItemLayouts }
     val lineColor = MaterialTheme.colorScheme.surfaceVariant
-    val linePxSize = with(timetableState.density) { timeTableLineStrokeSize.toPx() }
+    val linePxSize = with(timetableState.density) { TimetableSizes.lineStrokeSize.toPx() }
 
     LazyLayout(
         modifier = modifier
@@ -230,12 +230,10 @@ private data class TimetableItemLayout(
         else -> LocalDateTime.parse("2022-10-05T10:00:00")
             .toInstant(TimeZone.of("UTC+9"))
     }
-    val topOffset = with(density) { horizontalLineTopOffset.roundToPx() }
+    val topOffset = with(density) { TimetableSizes.horizontalLineTopOffset.roundToPx() }
     val height = (timetableItem.endsAt - timetableItem.startsAt)
         .inWholeMinutes.toInt() * minutePx
-    val width = with(density) {
-        timeTableColumnWidth.roundToPx()
-    }
+    val width = with(density) { TimetableSizes.columnWidth.roundToPx() }
     val left = rooms.indexOf(timetableItem.room) * width
     val top = (timetableItem.startsAt - dayStart)
         .inWholeMinutes.toInt() * minutePx + topOffset
@@ -420,7 +418,7 @@ private class TimetableScreen(
         }
     }
     val roomVerticalLines = derivedStateOf {
-        val width = with(density) { timeTableColumnWidth.toPx() }
+        val width = with(density) { TimetableSizes.columnWidth.toPx() }
         val rooms = timetableLayout.rooms
         (0..rooms.lastIndex).map {
             scrollState.scrollX + width * it
@@ -530,6 +528,8 @@ private suspend fun PointerInputScope.detectDragGestures(
     }
 }
 
-private val timeTableLineStrokeSize = 1.dp
-private val timeTableColumnWidth = 192.dp
-private val horizontalLineTopOffset = 16.dp
+object TimetableSizes {
+    val columnWidth = 192.dp
+    val lineStrokeSize = 1.dp
+    val horizontalLineTopOffset = 16.dp
+}


### PR DESCRIPTION
## Issue
- close #266 

## Overview (Required)
- Add timetable layout size object and share between timetable layout and rooms layout
- About the naming of the size object, I simply use xxxSizes but please suggest something better if has 😛
- Is it better to always have the size object instead of private vals for consistency? 🤔

