### PR TITLE
add compose compiler metrics option

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/AndroidComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/AndroidComposePlugin.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.primitive
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
+import java.io.File
 
 @Suppress("unused")
 class AndroidComposePlugin : Plugin<Project> {
@@ -12,6 +13,9 @@ class AndroidComposePlugin : Plugin<Project> {
                 buildFeatures.compose = true
                 composeOptions {
                     kotlinCompilerExtensionVersion = libs.findVersion("composeCompiler").get().toString()
+                }
+                kotlinOptions {
+                    freeCompilerArgs = freeCompilerArgs + buildComposeMetricsParameters()
                 }
             }
             dependencies {
@@ -33,4 +37,28 @@ class AndroidComposePlugin : Plugin<Project> {
             }
         }
     }
+}
+
+private fun Project.buildComposeMetricsParameters(): List<String> {
+    val metricParameters = mutableListOf<String>()
+    val enableMetricsProvider = project.providers.gradleProperty("enableComposeCompilerMetrics")
+    val enableMetrics = (enableMetricsProvider.orNull == "true")
+    if (enableMetrics) {
+        val metricsFolder = File(project.buildDir, "compose-metrics")
+        metricParameters.add("-P")
+        metricParameters.add(
+            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + metricsFolder.absolutePath
+        )
+    }
+
+    val enableReportsProvider = project.providers.gradleProperty("enableComposeCompilerReports")
+    val enableReports = (enableReportsProvider.orNull == "true")
+    if (enableReports) {
+        val reportsFolder = File(project.buildDir, "compose-reports")
+        metricParameters.add("-P")
+        metricParameters.add(
+            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder.absolutePath
+        )
+    }
+    return metricParameters.toList()
 }


### PR DESCRIPTION
## Issue
- close #142

## Overview (Required)
- Add options to output compose compiler metrics/reports
  - Metrics/reports are written in build dir in each modules. e.g. `core-designsystem/build/compose-metrics/core-designsystem_debug-module.json`

## Links
- https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/compiler-metrics.md
- https://github.com/android/nowinandroid/pull/125

