### PR TITLE
Fix extrernal service image button to match Material Design Accessibility

### DIFF
--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
@@ -108,7 +108,7 @@ fun About(
                     .padding(
                         start = 16.dp,
                         end = 16.dp,
-                        bottom = 32.dp,
+                        bottom = 14.dp,
                     ),
                 verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {
@@ -122,25 +122,22 @@ fun About(
                     ),
                     text = stringResource(id = string.about_description)
                 )
+            }
+            val context = LocalContext.current
 
-                val context = LocalContext.current
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    ExternalServiceImage(
-                        context = context,
-                        serviceType = ExternalServices.Twitter
-                    )
-                    ExternalServiceImage(
-                        context = context,
-                        serviceType = ExternalServices.Youtube
-                    )
-                    ExternalServiceImage(
-                        context = context,
-                        serviceType = ExternalServices.Medium
-                    )
-                }
+            Row(modifier = Modifier.padding(start = 4.dp, bottom = 22.dp)) {
+                ExternalServiceImage(
+                    context = context,
+                    serviceType = ExternalServices.Twitter
+                )
+                ExternalServiceImage(
+                    context = context,
+                    serviceType = ExternalServices.Youtube
+                )
+                ExternalServiceImage(
+                    context = context,
+                    serviceType = ExternalServices.Medium
+                )
             }
             Divider(
                 modifier = Modifier
@@ -255,13 +252,14 @@ private fun ExternalServiceImage(
 ) {
     Image(
         modifier = Modifier
-            .size(24.dp)
             .clickable {
                 navigateToExternalServices(
                     context = context,
                     serviceType = serviceType
                 )
-            },
+            }
+            .padding(12.dp)
+            .size(24.dp),
         imageVector = ImageVector.vectorResource(id = serviceType.iconRes),
         contentDescription = serviceType.contentDescription,
     )


### PR DESCRIPTION
## Issue
none

## Overview (Required)
- On the About screen, external service image buttons are too small and difficult to tap. Material Design recommends that the size of buttons should be 48dp or more. So, I fixed buttons paddings and other layouts paddings.

## Links
- [Accessibility - Material Design](https://material.io/design/usability/accessibility.html#layout-and-typography)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/31027685/189101633-06d84c8b-6e6f-4b2d-b80e-eca5bbefe6d8.png" width="300" /> | <img src="https://user-images.githubusercontent.com/31027685/189101719-6fa0f7b5-d260-4931-8e09-40bc12acb0ce.png" width="300" />
