### PR TITLE
:sparkles: Add Added a simple test.

### DIFF
--- a/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
+++ b/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class AnnouncementScreenRobot @Inject constructor() {
 
     context(RobotTestRule)
-    fun checkAnnouncementVisible() {
+    fun checkAnnouncementTitleVisible() {
         // TODO: Language-specific testing
         val appBarTitleText = composeTestRule.activity
             .getString(string.announcement_top_app_bar_title)

--- a/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
+++ b/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
@@ -1,0 +1,29 @@
+package io.github.droidkaigi.confsched2022.feature.announcement
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import io.github.droidkaigi.confsched2022.feature.announcement.R.string
+import io.github.droidkaigi.confsched2022.testing.RobotTestRule
+import javax.inject.Inject
+
+class AnnouncementScreenRobot @Inject constructor() {
+
+    context(RobotTestRule)
+    fun checkAnnouncementVisible() {
+        // TODO: Language-specific testing
+        val test = composeTestRule.activity.getString(string.announcement_top_app_bar_title)
+        composeTestRule.onNodeWithText(test).assertIsDisplayed()
+    }
+
+    operator fun invoke(
+        robotTestRule: RobotTestRule,
+        function: context(RobotTestRule) AnnouncementScreenRobot.() -> Unit
+    ) {
+        robotTestRule.composeTestRule.setContent {
+            AnnouncementScreenRoot(
+                onNavigationIconClick = {}
+            )
+        }
+        function(robotTestRule, this@AnnouncementScreenRobot)
+    }
+}

--- a/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
+++ b/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
@@ -11,7 +11,8 @@ class AnnouncementScreenRobot @Inject constructor() {
     context(RobotTestRule)
     fun checkAnnouncementVisible() {
         // TODO: Language-specific testing
-        val appBarTitleText = composeTestRule.activity.getString(string.announcement_top_app_bar_title)
+        val appBarTitleText = composeTestRule.activity
+            .getString(string.announcement_top_app_bar_title)
         composeTestRule.onNodeWithText(appBarTitleText).assertIsDisplayed()
     }
 

--- a/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
+++ b/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
@@ -11,8 +11,8 @@ class AnnouncementScreenRobot @Inject constructor() {
     context(RobotTestRule)
     fun checkAnnouncementVisible() {
         // TODO: Language-specific testing
-        val test = composeTestRule.activity.getString(string.announcement_top_app_bar_title)
-        composeTestRule.onNodeWithText(test).assertIsDisplayed()
+        val appBarTitleText = composeTestRule.activity.getString(string.announcement_top_app_bar_title)
+        composeTestRule.onNodeWithText(appBarTitleText).assertIsDisplayed()
     }
 
     operator fun invoke(

--- a/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenTest.kt
+++ b/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenTest.kt
@@ -1,0 +1,23 @@
+package io.github.droidkaigi.confsched2022.feature.announcement
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.github.droidkaigi.confsched2022.testing.RobotTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+@RunWith(AndroidJUnit4::class)
+@HiltAndroidTest
+class AnnouncementScreenTest {
+    @get:Rule val robotTestRule = RobotTestRule(this)
+    @Inject lateinit var announcementScreenRobot: AnnouncementScreenRobot
+
+    @Test
+    fun checkAnnouncementVisible() {
+        announcementScreenRobot(robotTestRule) {
+            checkAnnouncementVisible()
+        }
+    }
+}

--- a/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenTest.kt
+++ b/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenTest.kt
@@ -17,7 +17,7 @@ class AnnouncementScreenTest {
     @Test
     fun checkAnnouncementVisible() {
         announcementScreenRobot(robotTestRule) {
-            checkAnnouncementVisible()
+            checkAnnouncementTitleVisible()
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #300 

## Overview (Required)
- Test that the title of the notification screen is displayed.
  - I thought it would be better to add a test for each of JP and EN, but I couldn't figure out how to test for each language. 🤔

## Links
- Nothing.