### PR TITLE
:wrench: Fix Fixed a bug in the session details screen.

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -283,7 +283,7 @@ fun SessionScheduleInfo(
     val sessionEndDateTime = endTime
         .toLocalDateTime(TimeZone.currentSystemDefault())
 
-    fun LocalDateTime.toTime() = "$hour:$minute"
+    fun LocalDateTime.toTime() = "$hour:${minute.toString().padStart(2, '0')}"
 
     val sessionSchedule =
         "${sessionStartDateTime.monthNumber}月 ${sessionStartDateTime.dayOfMonth}日 " +


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- Fixed a problem in which two-digit minutes were not displayed when one-digit minutes were used.

## Links
- Nothing.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13657682/189183314-44b41478-ab73-4f91-8851-4d7be2405006.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13657682/189183309-204794ad-a3e2-4109-8348-473a7db37b41.png" width="300" />