### PR TITLE
Make SmallTopAppBar TopAppBar

### DIFF
--- a/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/theme/KaigiTopAppBar.kt
+++ b/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/theme/KaigiTopAppBar.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SmallTopAppBar
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
@@ -29,7 +29,7 @@ fun KaigiTopAppBar(
     title: (@Composable RowScope.() -> Unit),
     trailingIcons: (@Composable RowScope.() -> Unit)? = null,
 ) {
-    SmallTopAppBar(
+    TopAppBar(
         modifier = modifier,
         title = {
             Row(

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -21,8 +21,8 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SmallTopAppBar
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
@@ -109,7 +109,7 @@ fun SessionDetailTopAppBar(
     modifier: Modifier = Modifier,
     elevation: Dp = 0.dp,
 ) {
-    SmallTopAppBar(
+    TopAppBar(
         modifier = modifier,
         navigationIcon = {
             IconButton(onClick = onBackIconClick) {


### PR DESCRIPTION
## Issue
- close #299

## Overview (Required)
- I migrate  SmallTopAppBar to TopAppBar Because the experimental Material 3 SmallTopAppBar function is deprecated.

## Links
- https://developer.android.com/jetpack/androidx/releases/compose-material3?hl=en#1.0.0-beta02

## Screenshot
N/A