### PR TITLE
Support vertical pinch in/out on timetable

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
@@ -114,7 +114,7 @@ private data class HoursLayout(
 ) {
     var hoursHeight = 0
     var hoursWidth = 0
-    val minutePx = with(density) { (4.23).dp.roundToPx() }
+    val minutePx = with(density) { TimetableSizes.minuteHeight.roundToPx() }
     val hoursLayouts = hours.mapIndexed { index, it ->
         val hoursItemLayout = HoursItemLayout(
             index = index,

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 
 @Composable
 fun HoursItem(
@@ -117,7 +118,7 @@ private data class HoursLayout(
 ) {
     var hoursHeight = 0
     var hoursWidth = 0
-    val minutePx = with(density) { TimetableSizes.minuteHeight.times(verticalScale).roundToPx() }
+    val minutePx = with(density) { TimetableSizes.minuteHeight.times(verticalScale).toPx() }
     val hoursLayouts = hours.mapIndexed { index, it ->
         val hoursItemLayout = HoursItemLayout(
             index = index,
@@ -143,12 +144,12 @@ private data class HoursLayout(
 
 private data class HoursItemLayout(
     val density: Density,
-    val minutePx: Int,
+    val minutePx: Float,
     val index: Int
 ) {
     val topOffset = with(density) { horizontalLineTopOffset.roundToPx() }
     val itemOffset = with(density) { hoursItemTopOffset.roundToPx() }
-    val height = minutePx * 60
+    val height = (minutePx * 60).roundToInt()
     val width = with(density) { hoursWidth.roundToPx() }
     val left = 0
     val top = index * height + topOffset - itemOffset

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
@@ -46,11 +46,13 @@ fun Hours(
         content(modifier, hoursList[index])
     }
     val density = timetableState.density
+    val verticalScale = timetableState.screenScaleState.verticalScale
     val scrollState = timetableState.screenScrollState
-    val hoursLayout = remember(hoursList) {
+    val hoursLayout = remember(hoursList, verticalScale) {
         HoursLayout(
             hours = hoursList,
             density = density,
+            verticalScale = verticalScale,
         )
     }
     val hoursScreen = remember(hoursLayout, density) {
@@ -111,10 +113,11 @@ fun Hours(
 private data class HoursLayout(
     val hours: List<String>,
     val density: Density,
+    val verticalScale: Float,
 ) {
     var hoursHeight = 0
     var hoursWidth = 0
-    val minutePx = with(density) { TimetableSizes.minuteHeight.roundToPx() }
+    val minutePx = with(density) { TimetableSizes.minuteHeight.times(verticalScale).roundToPx() }
     val hoursLayouts = hours.mapIndexed { index, it ->
         val hoursItemLayout = HoursItemLayout(
             index = index,

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -162,6 +162,7 @@ fun Timetable(
 ) {
     HorizontalPager(
         count = days.size,
+        modifier = modifier,
         state = pagerState
     ) { dayIndex ->
         val day = days[dayIndex]
@@ -169,10 +170,9 @@ fun Timetable(
         val timetableState = rememberTimetableState()
         val coroutineScope = rememberCoroutineScope()
 
-        Row(modifier = modifier) {
+        Row {
             Hours(
                 timetableState = timetableState,
-                modifier = modifier,
             ) { modifier, hour ->
                 HoursItem(hour = hour, modifier = modifier)
             }

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.feature.sessions
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -172,6 +173,9 @@ fun Timetable(
 
         Row {
             Hours(
+                modifier = modifier.transformable(
+                    rememberTransformableStateForScreenScale(timetableState.screenScaleState),
+                ),
                 timetableState = timetableState,
             ) { modifier, hour ->
                 HoursItem(hour = hour, modifier = modifier)
@@ -193,6 +197,7 @@ fun Timetable(
                     TimetableItem(
                         timetableItem = timetableItem,
                         isFavorited = isFavorited,
+                        verticalScale = timetableState.screenScaleState.verticalScale,
                         modifier = Modifier
                             .clickable(
                                 onClick = { onTimetableClick(timetableItem.id) }

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -161,6 +161,7 @@ fun Timetable(
     days: Array<DroidKaigi2022Day>,
     onTimetableClick: (TimetableItemId) -> Unit,
 ) {
+    val screenScaleState = rememberScreenScaleState()
     HorizontalPager(
         count = days.size,
         modifier = modifier,
@@ -168,7 +169,7 @@ fun Timetable(
     ) { dayIndex ->
         val day = days[dayIndex]
         val timetable = scheduleState.schedule.dayToTimetable[day].orEmptyContents()
-        val timetableState = rememberTimetableState()
+        val timetableState = rememberTimetableState(screenScaleState = screenScaleState)
         val coroutineScope = rememberCoroutineScope()
 
         Row {

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -263,7 +263,7 @@ private data class TimetableLayout(val timetable: Timetable, val density: Densit
     var timetableHeight = 0
     var timetableWidth = 0
     val minutePx = with(density) {
-        (4.23).dp.roundToPx()
+        TimetableSizes.minuteHeight.roundToPx()
     }
     val timetableLayouts = timetable.timetableItems.map {
         val timetableItemLayout = TimetableItemLayout(
@@ -530,4 +530,5 @@ private suspend fun PointerInputScope.detectDragGestures(
 object TimetableSizes {
     val columnWidth = 192.dp
     val lineStrokeSize = 1.dp
+    val minuteHeight = (4.23).dp
 }

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -59,6 +59,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -225,7 +226,7 @@ private data class TimetableItemLayout(
     val rooms: List<TimetableRoom>,
     val dayStartTime: Instant,
     val density: Density,
-    val minutePx: Int
+    val minutePx: Float
 ) {
     val dayStart = when (timetableItem.day) {
         Day1 -> LocalDateTime.parse("2022-10-05T10:00:00")
@@ -237,12 +238,11 @@ private data class TimetableItemLayout(
         else -> LocalDateTime.parse("2022-10-05T10:00:00")
             .toInstant(TimeZone.of("UTC+9"))
     }
-    val height = (timetableItem.endsAt - timetableItem.startsAt)
-        .inWholeMinutes.toInt() * minutePx
+    val height =
+        ((timetableItem.endsAt - timetableItem.startsAt).inWholeMinutes * minutePx).roundToInt()
     val width = with(density) { TimetableSizes.columnWidth.roundToPx() }
     val left = rooms.indexOf(timetableItem.room) * width
-    val top = (timetableItem.startsAt - dayStart)
-        .inWholeMinutes.toInt() * minutePx
+    val top = ((timetableItem.startsAt - dayStart).inWholeMinutes * minutePx).toInt()
     val right = left + width
     val bottom = top + height
 
@@ -273,9 +273,7 @@ private data class TimetableLayout(
     val dayStartTime = timetable.timetableItems.minOfOrNull { it.startsAt }
     var timetableHeight = 0
     var timetableWidth = 0
-    val minutePx = with(density) {
-        TimetableSizes.minuteHeight.times(verticalScale).roundToPx()
-    }
+    val minutePx = with(density) { TimetableSizes.minuteHeight.times(verticalScale).toPx() }
     val timetableLayouts = timetable.timetableItems.map {
         val timetableItemLayout = TimetableItemLayout(
             timetableItem = it,

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -230,13 +230,12 @@ private data class TimetableItemLayout(
         else -> LocalDateTime.parse("2022-10-05T10:00:00")
             .toInstant(TimeZone.of("UTC+9"))
     }
-    val topOffset = with(density) { TimetableSizes.horizontalLineTopOffset.roundToPx() }
     val height = (timetableItem.endsAt - timetableItem.startsAt)
         .inWholeMinutes.toInt() * minutePx
     val width = with(density) { TimetableSizes.columnWidth.roundToPx() }
     val left = rooms.indexOf(timetableItem.room) * width
     val top = (timetableItem.startsAt - dayStart)
-        .inWholeMinutes.toInt() * minutePx + topOffset
+        .inWholeMinutes.toInt() * minutePx
     val right = left + width
     val bottom = top + height
 
@@ -531,5 +530,4 @@ private suspend fun PointerInputScope.detectDragGestures(
 object TimetableSizes {
     val columnWidth = 192.dp
     val lineStrokeSize = 1.dp
-    val horizontalLineTopOffset = 16.dp
 }

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -8,12 +8,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTag
@@ -24,6 +27,7 @@ import io.github.droidkaigi.confsched2022.model.TimetableItem
 fun TimetableItem(
     timetableItem: TimetableItem,
     isFavorited: Boolean,
+    verticalScale: Float,
     modifier: Modifier = Modifier
 ) {
     val roomName = timetableItem.room.name
@@ -33,26 +37,33 @@ fun TimetableItem(
     } else {
         Color(roomColor).copy(alpha = 0.2F)
     }
-    Column(
-        modifier
-            .background(color, MaterialTheme.shapes.medium)
-            .border(2.dp, Color(roomColor), MaterialTheme.shapes.medium)
-            .padding(8.dp)
-            .semantics { contentDescription = "isFavorited$isFavorited" }
-            .testTag("favorite")
+    val localDensity = LocalDensity.current.let {
+        Density(it.density * verticalScale, it.fontScale)
+    }
+    CompositionLocalProvider(
+        LocalDensity provides localDensity,
     ) {
-        Text(
-            text = timetableItem.title.currentLangTitle,
-            color = Color.White,
-            modifier = Modifier
-                .padding(bottom = 8.dp)
-                .weight(weight = 1f, fill = false)
-                .fillMaxWidth(),
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.titleMedium.copy(
-                letterSpacing = 0.1.sp
+        Column(
+            modifier
+                .background(color, MaterialTheme.shapes.medium)
+                .border(2.dp, Color(roomColor), MaterialTheme.shapes.medium)
+                .padding(8.dp)
+                .semantics { contentDescription = "isFavorited$isFavorited" }
+                .testTag("favorite")
+        ) {
+            Text(
+                text = timetableItem.title.currentLangTitle,
+                color = Color.White,
+                modifier = Modifier
+                    .padding(bottom = 8.dp)
+                    .weight(weight = 1f, fill = false)
+                    .fillMaxWidth(),
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    letterSpacing = 0.1.sp
+                )
             )
-        )
-        KaigiTag { Text(timetableItem.minutesString) }
+            KaigiTag { Text(timetableItem.minutesString) }
+        }
     }
 }


### PR DESCRIPTION
## Issue
- close #290

## Overview (Required)
- Support zoom in/out of timetable by multitouch pinch in/out
- Dragging timetable and horizontal swipe to change tab are still working along with pinch in/out
  <video src="https://user-images.githubusercontent.com/12084705/189347202-7482470d-740a-4695-a30d-c44a1d9237cb.mp4">

## Change details

### Resolved several minor issues first to implement pinch in/out correctly

- 82219cd5c2ff127df1f4a8f33f16ecc9685aae44: Delete unnecessary top offset from `TimetableItemLayout`
  - There was unnecessary top offset in `TimetableItemLayout` and sessions were laid out at slightly wrong positions
  - "Welcome Talk" will start 10:00 but its top was misaligned with the 10:00 line
    |Before|After|
    |---|---|
    |<img width="300" src="https://user-images.githubusercontent.com/12084705/189347826-ccc006b2-d173-456a-9a28-29545f93f4f1.png">|<img width="300" src="https://user-images.githubusercontent.com/12084705/189347828-784eab4c-c64b-4e5f-b8ff-9ddbba51c31f.png">|
  - This fix is required later to correctly calculate minimum scale of pinch out based on the timetable height
- 22f590cfa7c9d078c1dc05a077ffd6b3e9e1e66c: Use received `Modifier` correctly in `Timetable` composable
  - It should be used at the outer composable in `Timetable` but it was used at other multiple composables
- 98ef30e5fe5c2dd21ac2be439ff68185359b7579: Define magic number `4.23.dp` in `TimetableSizes`
  - It represents the height of "1 minute" in the timetable
  - E.g. If the duration of a session is 40 min, it should be laid out with 4.23 * 40 = 169.2 dp height

### f799ad158e73db9d28db579d2b4c7b9d489a6e92: Implemented pinching timetable

- This commit is the core fix of this PR
- Followings are main changes
- How to manager current vertical scale
  - Added `ScreenScaleState` class to manage vertical scale
    ```kotlin
    @Stable
    class ScreenScaleState(
        initialVerticalScale: Float = 1f
    ) {
        private val verticalScaleState = mutableStateOf(initialVerticalScale)
    
        val verticalScale: Float
            get() = verticalScaleState.value
        
        ...
    }
    ```
  - The instance of `ScreenScaleState` is managed as a member of `TimetableState`
    ```diff
    
     data class TimetableState(
         val screenScrollState: ScreenScrollState,
    +    val screenScaleState: ScreenScaleState,
         val density: Density,
     )
    ```
- How to detect multitouch pinch in/out
  - [`transformable`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/gestures/package-summary#(androidx.compose.ui.Modifier).transformable(androidx.compose.foundation.gestures.TransformableState,kotlin.Boolean,kotlin.Boolean)) modifier is utilized to detect multitouch gestures
  - We implemented detecting drag by `pointerInput` modifier in `Timetable`. We can avoid conflict between `pointerInput` and `transformable` by adding `transformable` modifier after `pointerInput` modifier
    ```diff
         LazyLayout(
             modifier = modifier
                 ...
                 .pointerInput(Unit) {
                     ...
                 }
    +            .transformable(
    +                rememberTransformableState { zoomChange, _, _ ->
    +                    timetableState.screenScaleState.updateVerticalScale(
    +                        timetableState.screenScaleState.verticalScale * zoomChange
    +                    )
    +                }
    +            )
    ```
  - Added `transformable` modifier to `Hours` composable as well to support pinch on hours area
- How to control the vertical scale of the timetable
  - The height of the timetable and its items are calculated based on the height of "1 minute" = `TimetableSizes.minuteHeight` in `HoursLayout` and `TimetableLayout`
  - We can change the vertical scale of the timetable by multiplying `TimetableSizes.minuteHeight` in `HoursLayout` and `TimetableLayout`
    ```diff
     private data class HoursLayout(
         val hours: List<String>,
         val density: Density,
    +    val verticalScale: Float,
     ) {
         var hoursHeight = 0
         var hoursWidth = 0
    -    val minutePx = with(density) { TimetableSizes.minuteHeight.roundToPx() }
    +    val minutePx = with(density) { TimetableSizes.minuteHeight.times(verticalScale).roundToPx() }
    ```
- How to change the scale of the content of session boxes
  - Overwrite `LocalDensity` of `TimetableItem` to scale the texts
    ```diff
     fun TimetableItem(
         timetableItem: TimetableItem,
         isFavorited: Boolean,
    +    verticalScale: Float,
         modifier: Modifier = Modifier
     ) {
         ...
    +    val localDensity = LocalDensity.current.let {
    +        Density(it.density * verticalScale, it.fontScale)
    +    }
    +    CompositionLocalProvider(
    +        LocalDensity provides localDensity,
    +    ) {
             ...
    +    }
     }
    ```
  - [`scale`](https://developer.android.com/reference/kotlin/androidx/compose/ui/draw/package-summary#(androidx.compose.ui.Modifier).scale(kotlin.Float)) modifier doesn't fit our use case because the modifier doesn't change widget layouts
    - Widgets are laid out with their **original size** and the scaled drawing is displayed at the center of the layout bounds if we use `scale` :point_down:
      <video src="https://user-images.githubusercontent.com/12084705/189364461-8670bd57-b4b4-4e24-87af-16a5b99cf0cc.mp4">

### Added several enhancements

- f5fc93b95516979d4b8af715f6eed417416622ef: Avoid rounding `minutePx` for smoother zooming
  - `minutePx` represents the height of "1 minute" in px
  - `minutePx` was rounded into `Int` first then used to calculate several heights
  - Keep `minutePx` in `Float` and round the calculated heights to `Int` after all calculation for smoother zooming
    |Before|After|
    |---|---|
    |<video src="https://user-images.githubusercontent.com/12084705/189365425-a14809fc-870f-4fa8-a430-02aebabdd509.mp4">|<video src="https://user-images.githubusercontent.com/12084705/189365444-02e9b1f5-d3ed-46f0-a1f0-d57a8b07de47.mp4">|
- 60ab6c88adf362103600a05d8b2a386d60a51f53: Define the minimum scale ratio to prevent zooming out too much
  - This fix is based on [the original request](https://github.com/DroidKaigi/conference-app-2022/issues/290#issue-1366034013)
    > Min scale: All sessions in **a room** are displayed without scrolling

    |Before|After|
    |---|---|
    |<video src="https://user-images.githubusercontent.com/12084705/189366954-5436f997-856f-4c84-966a-44bc433eb743.mp4">|<video src="https://user-images.githubusercontent.com/12084705/189366942-d3e76bec-6d0a-470b-82a9-4ea6f919a9d4.mp4">
- 9fbd74e7742dd93b60d1c0385f46c62c9e762821: Share zoom ratio between pages
    |Before|After|
    |---|---|
    |<video src="https://user-images.githubusercontent.com/12084705/189367051-c9cc72f4-4f57-406b-baba-0dbf935b7ad3.mp4">|<video src="https://user-images.githubusercontent.com/12084705/189366999-58021490-816f-4125-8830-090ade95f644.mp4">

## Screenshot

https://user-images.githubusercontent.com/12084705/189369237-0525a6e6-9d50-4626-bd2c-687da542d595.mp4