### PR TITLE
the indicator for loading contributors is located in the upper left c…

### DIFF
--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -6,9 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -6,8 +6,12 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -68,7 +72,12 @@ fun Contributors(
         }
     ) {
         if (uiModel.contributorsState !is Loaded) {
-            CircularProgressIndicator()
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
             return@KaigiScaffold
         }
         val contributors = uiModel.contributorsState.contributors


### PR DESCRIPTION
## Issue
- close #312 

## Overview (Required)
- indicator loading Contributors is located in the upper left corner.
- fix location to center

## Links
- nothing

## Screenshot
Before | After

<img src="https://user-images.githubusercontent.com/45583423/189293154-63e72081-6eb2-4756-b34d-e25ccf11a2b4.png" width="300" /> | <img src="https://user-images.githubusercontent.com/51434873/189372349-7b8a809d-3799-4e32-94ab-a303f18279d4.png" width="300" />
