### PR TITLE
:sparkles: Add Prevent classes not used in Jetpack Compose from appearing in suggestions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ local.properties
 *.iml
 .idea/*
 !.idea/copyright
+!.idea/codeInsightSettings.xml
+
 # Keep the code styles.
 !/.idea/codeStyles
 /.idea/codeStyles/*

--- a/.idea/codeInsightSettings.xml
+++ b/.idea/codeInsightSettings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaProjectCodeInsightSettings">
+    <excluded-names>
+      <name>java.lang.reflect.Modifier</name>
+      <name>java.nio.file.WatchEvent.Modifier</name>
+      <name>android.view.Surface</name>
+      <name>androidx.core.content.pm.ShortcutInfoCompat.Surface</name>
+      <name>org.w3c.dom.Text</name>
+      <name>android.widget.Button</name>
+      <name>android.graphics.drawable.Icon</name>
+      <name>android.inputmethodservice.Keyboard.Row</name>
+      <name>java.time.format.TextStyle</name>
+      <name>org.threeten.bp.format.TextStyle</name>
+      <name>android.text.Layout.Alignment</name>
+      <name>android.widget.GridLayout.Alignment</name>
+      <name>android.graphics.Canvas</name>
+      <name>android.graphics.Color</name>
+      <name>android.graphics.Paint</name>
+    </excluded-names>
+  </component>
+</project>


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- As the title says.

## Links
- https://github.com/GetStream/whatsApp-clone-compose/blob/main/.idea/codeInsightSettings.xml

## Movie


https://user-images.githubusercontent.com/13657682/189455030-745343c9-cc0a-404e-8739-c73516a125ec.mov


https://user-images.githubusercontent.com/13657682/189455034-df8f4783-4c80-455b-a1a4-ed1416703c54.mov


