### PR TITLE
Hoist URL handling to KaigiApp

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
 
     implementation(libs.composeMaterialIcons)
     implementation(libs.composeMaterial3WindowSizeClass)
+    implementation(libs.androidXChromeCustomTabs)
     implementation(libs.androidxNavigationCompose)
     implementation(libs.androidxStartup)
     implementation(libs.hiltNavigationCompose)

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -70,7 +70,8 @@ import kotlinx.coroutines.launch
 fun KaigiApp(
     windowSizeClass: WindowSizeClass,
     kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState(),
-    kaigiExternalNavigationController: KaigiExternalNavigationController = rememberKaigiExternalNavigationController(),
+    kaigiExternalNavigationController: KaigiExternalNavigationController =
+        rememberKaigiExternalNavigationController(),
 ) {
     KaigiTheme {
         CompositionLocalProvider(

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -284,8 +284,7 @@ fun ColumnScope.DrawerSheetContent(
 }
 
 @Composable
-fun rememberKaigiExternalNavigationController(
-): KaigiExternalNavigationController {
+fun rememberKaigiExternalNavigationController(): KaigiExternalNavigationController {
     val context = LocalContext.current
     return remember(context) {
         KaigiExternalNavigationController(

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -1,5 +1,10 @@
 package io.github.droidkaigi.confsched2022
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
@@ -64,7 +69,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun KaigiApp(
     windowSizeClass: WindowSizeClass,
-    kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState()
+    kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState(),
+    kaigiExternalNavigationController: KaigiExternalNavigationController = rememberKaigiExternalNavigationController(),
 ) {
     KaigiTheme {
         CompositionLocalProvider(
@@ -101,10 +107,12 @@ fun KaigiApp(
                     contributorsNavGraph(
                         showNavigationIcon,
                         kaigiAppScaffoldState::onNavigationClick,
+                        onLinkClick = kaigiExternalNavigationController::navigate,
                     )
                     aboutNavGraph(
                         showNavigationIcon,
                         kaigiAppScaffoldState::onNavigationClick,
+                        onLinkClick = kaigiExternalNavigationController::navigate,
                     )
                     mapGraph()
                     announcementGraph(
@@ -270,6 +278,50 @@ fun ColumnScope.DrawerSheetContent(
                 thickness = 1.dp,
                 modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp)
             )
+        }
+    }
+}
+
+@Composable
+fun rememberKaigiExternalNavigationController(
+): KaigiExternalNavigationController {
+    val context = LocalContext.current
+    return remember(context) {
+        KaigiExternalNavigationController(
+            context,
+        )
+    }
+}
+
+class KaigiExternalNavigationController(
+    private val context: Context,
+) {
+
+    fun navigate(
+        url: String,
+        packageName: String? = null,
+    ) {
+        try {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            if (packageName != null) {
+                intent.setPackage(packageName)
+            }
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            navigateToCustomTab(
+                url = url,
+                context = context,
+            )
+        }
+    }
+
+    private fun navigateToCustomTab(url: String, context: Context) {
+        val uri = Uri.parse(url)
+        CustomTabsIntent.Builder().also { builder ->
+            builder.setShowTitle(true)
+            builder.build().also {
+                it.launchUrl(context, uri)
+            }
         }
     }
 }

--- a/feature-about/build.gradle.kts
+++ b/feature-about/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     testImplementation(projects.coreTesting)
 
     implementation(libs.accompanistPager)
-    implementation(libs.androidXChromeCustomTabs)
     implementation(libs.androidxActivityCompose)
     implementation(libs.androidxCoreKtx)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)

--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
@@ -1,11 +1,7 @@
 package io.github.droidkaigi.confsched2022.feature.about
 
-import android.content.ActivityNotFoundException
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.annotation.StringRes
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -53,15 +49,17 @@ fun AboutScreenRoot(
     modifier: Modifier = Modifier,
     showNavigationIcon: Boolean = true,
     onNavigationIconClick: () -> Unit = {},
+    onLinkClick: (url: String, packageName: String?) -> Unit = { _, _ -> },
     versionName: String? = versionName(LocalContext.current)
 ) {
-    About(showNavigationIcon, onNavigationIconClick, modifier, versionName)
+    About(showNavigationIcon, onNavigationIconClick, onLinkClick, modifier, versionName)
 }
 
 @Composable
 fun About(
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    onLinkClick: (url: String, packageName: String?) -> Unit,
     modifier: Modifier = Modifier,
     versionName: String?
 ) {
@@ -123,21 +121,15 @@ fun About(
                     text = stringResource(id = string.about_description)
                 )
             }
-            val context = LocalContext.current
 
             Row(modifier = Modifier.padding(start = 4.dp, bottom = 22.dp)) {
-                ExternalServiceImage(
-                    context = context,
-                    serviceType = ExternalServices.Twitter
-                )
-                ExternalServiceImage(
-                    context = context,
-                    serviceType = ExternalServices.Youtube
-                )
-                ExternalServiceImage(
-                    context = context,
-                    serviceType = ExternalServices.Medium
-                )
+                ExternalServices.values().forEach { serviceType ->
+                    ExternalServiceImage(
+                        serviceType = serviceType
+                    ) {
+                        onLinkClick(serviceType.url, serviceType.packageName)
+                    }
+                }
             }
             Divider(
                 modifier = Modifier
@@ -154,18 +146,7 @@ fun About(
                     imageVector = Icons.Outlined.Train,
                     textResId = string.about_access,
                     onClick = {
-                        val intent = Intent(
-                            Intent.ACTION_VIEW,
-                            Uri.parse(googleMapUrl)
-                        )
-                        try {
-                            context.startActivity(intent)
-                        } catch (e: ActivityNotFoundException) {
-                            navigateToCustomTab(
-                                url = googleMapUrl,
-                                context = context,
-                            )
-                        }
+                        onLinkClick(googleMapUrl, null)
                     }
                 )
 
@@ -247,50 +228,17 @@ private fun AuxiliaryInformationRow(
 
 @Composable
 private fun ExternalServiceImage(
-    context: Context,
     serviceType: ExternalServices,
+    onClick: () -> Unit,
 ) {
     Image(
         modifier = Modifier
-            .clickable {
-                navigateToExternalServices(
-                    context = context,
-                    serviceType = serviceType
-                )
-            }
+            .clickable(onClick = onClick)
             .padding(12.dp)
             .size(24.dp),
         imageVector = ImageVector.vectorResource(id = serviceType.iconRes),
         contentDescription = serviceType.contentDescription,
     )
-}
-
-private fun navigateToExternalServices(
-    context: Context,
-    serviceType: ExternalServices,
-) {
-    try {
-        Intent(Intent.ACTION_VIEW).also {
-            it.setPackage(serviceType.packageName)
-            it.data = Uri.parse(serviceType.url)
-            context.startActivity(it)
-        }
-    } catch (e: ActivityNotFoundException) {
-        navigateToCustomTab(
-            url = serviceType.url,
-            context = context,
-        )
-    }
-}
-
-private fun navigateToCustomTab(url: String, context: Context) {
-    val uri = Uri.parse(url)
-    CustomTabsIntent.Builder().also { builder ->
-        builder.setShowTitle(true)
-        builder.build().also {
-            it.launchUrl(context, uri)
-        }
-    }
 }
 
 private fun versionName(context: Context) = runCatching {

--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/AboutNavGraph.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/AboutNavGraph.kt
@@ -6,11 +6,13 @@ import androidx.navigation.compose.composable
 fun NavGraphBuilder.aboutNavGraph(
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    onLinkClick: (url: String, packageName: String?) -> Unit,
 ) {
     composable(route = AboutNavGraph.aboutRoute) {
         AboutScreenRoot(
             showNavigationIcon = showNavigationIcon,
             onNavigationIconClick = onNavigationIconClick,
+            onLinkClick = onLinkClick,
         )
     }
 }

--- a/feature-announcement/build.gradle.kts
+++ b/feature-announcement/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.composeMaterial3)
     implementation(libs.composeUiToolingPreview)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidXChromeCustomTabs)
     implementation(libs.androidxActivityCompose)
     implementation(libs.accompanistPager)
     implementation(libs.coilCompose)

--- a/feature-contributors/build.gradle.kts
+++ b/feature-contributors/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.composeMaterial3)
     implementation(libs.composeUiToolingPreview)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidXChromeCustomTabs)
     implementation(libs.androidxActivityCompose)
     implementation(libs.accompanistPager)
     implementation(libs.coilCompose)

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -1,10 +1,5 @@
 package io.github.droidkaigi.confsched2022.feature.contributors
 
-import android.content.ActivityNotFoundException
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -41,11 +36,12 @@ import io.github.droidkaigi.confsched2022.feature.contributors.ContributorsUiMod
 fun ContributorsScreenRoot(
     modifier: Modifier = Modifier,
     showNavigationIcon: Boolean = true,
-    onNavigationIconClick: () -> Unit = {}
+    onNavigationIconClick: () -> Unit = {},
+    onLinkClick: (url: String, packageName: String?) -> Unit = { _, _ -> },
 ) {
     val viewModel = hiltViewModel<ContributorsViewModel>()
     val uiModel by viewModel.uiModel
-    Contributors(uiModel, showNavigationIcon, onNavigationIconClick, modifier)
+    Contributors(uiModel, showNavigationIcon, onNavigationIconClick, onLinkClick, modifier)
 }
 
 @Composable
@@ -53,6 +49,7 @@ fun Contributors(
     uiModel: ContributorsUiModel,
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    onLinkClick: (url: String, packageName: String?) -> Unit,
     modifier: Modifier = Modifier
 ) {
     KaigiScaffold(
@@ -93,18 +90,7 @@ fun Contributors(
                         .padding(top = 16.dp)
                         .clickable {
                             contributor.profileUrl?.let { url ->
-                                try {
-                                    Intent(Intent.ACTION_VIEW).also {
-                                        it.setPackage("com.github.android")
-                                        it.data = Uri.parse(url)
-                                        context.startActivity(it)
-                                    }
-                                } catch (e: ActivityNotFoundException) {
-                                    navigateToCustomTab(
-                                        url = url,
-                                        context = context,
-                                    )
-                                }
+                                onLinkClick(url, "com.github.android")
                             }
                         },
                     verticalAlignment = Alignment.CenterVertically,
@@ -125,16 +111,6 @@ fun Contributors(
                     )
                 }
             }
-        }
-    }
-}
-
-private fun navigateToCustomTab(url: String, context: Context) {
-    val uri = Uri.parse(url)
-    CustomTabsIntent.Builder().also { builder ->
-        builder.setShowTitle(true)
-        builder.build().also {
-            it.launchUrl(context, uri)
         }
     }
 }

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsNavGraph.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsNavGraph.kt
@@ -6,11 +6,13 @@ import androidx.navigation.compose.composable
 fun NavGraphBuilder.contributorsNavGraph(
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    onLinkClick: (url: String, packageName: String?) -> Unit,
 ) {
     composable(route = ContributorsNavGraph.contributorsRoute) {
         ContributorsScreenRoot(
             showNavigationIcon = showNavigationIcon,
             onNavigationIconClick = onNavigationIconClick,
+            onLinkClick = onLinkClick,
         )
     }
 }

--- a/feature-map/build.gradle.kts
+++ b/feature-map/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.composeMaterial3)
     implementation(libs.composeUiToolingPreview)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidXChromeCustomTabs)
     implementation(libs.androidxActivityCompose)
     implementation(libs.accompanistPager)
     implementation(libs.coilCompose)


### PR DESCRIPTION
## Issue
- close #296

## Overview (Required)
- Hoist URL handling to KaigiApp
- Remove all `androidx.browser` dependencies in feature modules.
