### PR TITLE
Add padding to Contributors icon

### DIFF
--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -91,7 +91,8 @@ fun Contributors(
                                     contributor.profileUrl?.let { url ->
                                         onLinkClick(url, "com.github.android")
                                     }
-                                },
+                                }
+                                .padding(vertical = 12.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Spacer(modifier = Modifier.width(16.dp))


### PR DESCRIPTION
## Issue
- close #342

## Overview (Required)
- Add padding to Contributors list item row.

## Screenshot
| Before | After |
| :--: | :--: |
|![screenshot-before](https://user-images.githubusercontent.com/16633277/189481018-d7161e8a-76ce-4a8a-bcca-33d56680b539.png) | ![screenshot-after](https://user-images.githubusercontent.com/16633277/189481029-2ae1d036-2f0e-4148-af86-baca6a16b04b.png) |
| <img src="" width="300" /> | <img src="" width="300" /> |
