### PR TITLE
Calculate the height from the original time minus 1 minutes and add end padding

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -56,7 +56,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.DateTimeUnit.Companion
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -55,9 +55,12 @@ import io.github.droidkaigi.confsched2022.model.fake
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DateTimeUnit.Companion
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
 import kotlinx.datetime.toInstant
 import kotlin.math.roundToInt
 
@@ -248,8 +251,9 @@ private data class TimetableItemLayout(
         else -> LocalDateTime.parse("2022-10-05T10:00:00")
             .toInstant(TimeZone.of("UTC+9"))
     }
+    private val displayEndsAt = timetableItem.endsAt.minus(1, DateTimeUnit.MINUTE)
     val height =
-        ((timetableItem.endsAt - timetableItem.startsAt).inWholeMinutes * minutePx).roundToInt()
+        ((displayEndsAt - timetableItem.startsAt).inWholeMinutes * minutePx).roundToInt()
     val width = with(density) { TimetableSizes.columnWidth.roundToPx() }
     val left = rooms.indexOf(timetableItem.room) * width
     val top = ((timetableItem.startsAt - dayStart).inWholeMinutes * minutePx).toInt()

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -45,7 +45,6 @@ fun TimetableItem(
     ) {
         Column(
             modifier
-                .padding(end = 4.dp)
                 .background(color, MaterialTheme.shapes.medium)
                 .border(2.dp, Color(roomColor), MaterialTheme.shapes.medium)
                 .padding(8.dp)

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -45,6 +45,7 @@ fun TimetableItem(
     ) {
         Column(
             modifier
+                .padding(end = 4.dp)
                 .background(color, MaterialTheme.shapes.medium)
                 .border(2.dp, Color(roomColor), MaterialTheme.shapes.medium)
                 .padding(8.dp)


### PR DESCRIPTION
## Issue
- close #345

## Overview (Required)
- As suggested, Calculate the height from the original time minus 1 minutes.
- ~💡In my opinion, I thought `TimetableItem` would be nice to have end padding, so I added it.~

~If you don't want the end padding, let me know so I can remove it.~ remove it 👍🏻
See https://github.com/DroidKaigi/conference-app-2022/pull/351#pullrequestreview-1103130117

## Screenshot
Before | After | After(include my idea) |
:--: | :--: | :--:
<img src="https://user-images.githubusercontent.com/7961496/189484842-2cfd82c8-9c39-4514-8eec-75eca22927aa.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7961496/189484847-d725b60e-9a46-4b03-967d-a84030ffdcfd.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7961496/189485029-a7fb02f8-74de-43d3-9003-8ec1c8ebe372.png" width="300" />
