### PR TITLE
Add about description in English

### DIFF
--- a/feature-about/src/main/res/values-en/strings.xml
+++ b/feature-about/src/main/res/values-en/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="about_top_app_bar_title">What is DroidKaigi?</string>
     <string name="about_title">What is DroidKaigi?</string>
-    <string name="about_description">DroidKaigiはエンジニアが主役のAndroidカンファレンスです。\nAndroid技術情報の共有とコミュニケーションを目的に、2022年10月5日(水)〜7日(金)の3日間開催します。</string>
+    <string name="about_description">DroidKaigi is a conference tailored for Android developers. It\'s scheduled to take place on the 5 to 7 of October 2022.</string>
     <string name="about_access">Access</string>
     <string name="about_staff">Staff List</string>
     <string name="about_privacy">Privacy Policy</string>


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2022/issues/349

## Overview (Required)

Add a description of about screen in English.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/25548003/189487547-db1bd686-e1e5-4f15-9ee3-9a12217faffe.png" width="300" /> | <img src="https://user-images.githubusercontent.com/25548003/189487557-4bc4eef3-95d1-4a67-ae75-4c2e7ea4bf45.png" width="300" />

