### PR TITLE
Add `modifier = Modifier` parameter to all composable function in Search

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -55,6 +55,7 @@ import io.github.droidkaigi.confsched2022.ui.UiLoadState.Success
 
 @Composable
 fun SearchRoot(
+    modifier: Modifier = Modifier,
     onItemClick: () -> Unit = {},
     onBookMarkClick: () -> Unit = {}
 ) {
@@ -69,6 +70,7 @@ fun SearchRoot(
 
 @Composable
 private fun SearchScreen(
+    modifier: Modifier = Modifier,
     uiModel: SessionsUiModel,
     onItemClick: () -> Unit,
     onBookMarkClick: () -> Unit,
@@ -81,7 +83,7 @@ private fun SearchScreen(
                 when (uiModel.state) {
                     is Error -> TODO()
                     is Success -> {
-                        SearchTextField(searchWord.value) {
+                        SearchTextField(searchWord = searchWord.value) {
                             searchWord.value = it
                         }
                         SearchedItemListField(
@@ -102,7 +104,11 @@ private fun SearchScreen(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
-private fun SearchTextField(searchWord: String, onSearchWordChange: (String) -> Unit) {
+private fun SearchTextField(
+    modifier: Modifier = Modifier,
+    searchWord: String,
+    onSearchWordChange: (String) -> Unit
+) {
     val keyboardController = LocalSoftwareKeyboardController.current
     Box(
         modifier = Modifier
@@ -143,6 +149,7 @@ private fun SearchTextField(searchWord: String, onSearchWordChange: (String) -> 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SearchedItemListField(
+    modifier: Modifier = Modifier,
     schedule: DroidKaigiSchedule,
     searchWord: String,
     onItemClick: () -> Unit,
@@ -168,7 +175,7 @@ private fun SearchedItemListField(
 }
 
 @Composable
-private fun SearchedHeader(day: DroidKaigi2022Day) {
+private fun SearchedHeader(modifier: Modifier = Modifier, day: DroidKaigi2022Day) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -185,6 +192,7 @@ private fun SearchedHeader(day: DroidKaigi2022Day) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SearchedItem(
+    modifier: Modifier = Modifier,
     timetableItemWithFavorite: TimetableItemWithFavorite,
     onItemClick: () -> Unit,
     onBookMarkClick: () -> Unit,
@@ -276,7 +284,7 @@ private fun SearchedItem(
 }
 
 @Composable
-private fun FullScreenLoading() {
+private fun FullScreenLoading(modifier: Modifier = Modifier) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -71,10 +71,10 @@ fun SearchRoot(
 
 @Composable
 private fun SearchScreen(
-    modifier: Modifier = Modifier,
     uiModel: SessionsUiModel,
     onItemClick: () -> Unit,
     onBookMarkClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val searchWord = rememberSaveable { mutableStateOf("") }
     KaigiScaffold(
@@ -151,11 +151,11 @@ private fun SearchTextField(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SearchedItemListField(
-    modifier: Modifier = Modifier,
     schedule: DroidKaigiSchedule,
     searchWord: String,
     onItemClick: () -> Unit,
-    onBookMarkClick: () -> Unit
+    onBookMarkClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier = modifier) {
         schedule.dayToTimetable.forEach { (dayToTimeTable, timeTable) ->

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -62,6 +62,7 @@ fun SearchRoot(
     val viewModel = hiltViewModel<SessionsViewModel>()
     val state: SessionsUiModel by viewModel.uiModel
     SearchScreen(
+        modifier = modifier,
         uiModel = state,
         onItemClick = onItemClick,
         onBookMarkClick = onBookMarkClick,
@@ -77,6 +78,7 @@ private fun SearchScreen(
 ) {
     val searchWord = rememberSaveable { mutableStateOf("") }
     KaigiScaffold(
+        modifier = modifier,
         topBar = {},
         content = {
             Column {
@@ -111,7 +113,7 @@ private fun SearchTextField(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 10.dp),
         contentAlignment = Alignment.Center
@@ -155,7 +157,7 @@ private fun SearchedItemListField(
     onItemClick: () -> Unit,
     onBookMarkClick: () -> Unit
 ) {
-    LazyColumn {
+    LazyColumn(modifier = modifier) {
         schedule.dayToTimetable.forEach { (dayToTimeTable, timeTable) ->
             val sessions =
                 timeTable.filtered(Filters(filterSession = true, searchWord = searchWord)).contents
@@ -177,7 +179,7 @@ private fun SearchedItemListField(
 @Composable
 private fun SearchedHeader(modifier: Modifier = Modifier, day: DroidKaigi2022Day) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .background(MaterialTheme.colorScheme.onPrimary)
@@ -199,7 +201,7 @@ private fun SearchedItem(
 ) {
     var contentHeight = 100.dp
     Box(
-        modifier = Modifier
+        modifier = modifier
             .wrapContentHeight()
             .heightIn(min = contentHeight)
             .clickable { onItemClick.invoke() }
@@ -286,7 +288,7 @@ private fun SearchedItem(
 @Composable
 private fun FullScreenLoading(modifier: Modifier = Modifier) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
         CircularProgressIndicator()

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -57,7 +57,7 @@ import io.github.droidkaigi.confsched2022.ui.UiLoadState.Success
 fun SearchRoot(
     modifier: Modifier = Modifier,
     onItemClick: () -> Unit = {},
-    onBookMarkClick: () -> Unit = {}
+    onBookMarkClick: () -> Unit = {},
 ) {
     val viewModel = hiltViewModel<SessionsViewModel>()
     val state: SessionsUiModel by viewModel.uiModel
@@ -109,7 +109,7 @@ private fun SearchScreen(
 private fun SearchTextField(
     modifier: Modifier = Modifier,
     searchWord: String,
-    onSearchWordChange: (String) -> Unit
+    onSearchWordChange: (String) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     Box(


### PR DESCRIPTION
## Issue
- close #323 

## Overview (Required)
- add `modifier` parameters to all composable function
- pass `modifier` to the root composable function
- chore: add trailing comma for function signatures

## Screenshot

Omitted because no effects to appearance of any UI.
