### PR TITLE
Fixed screen flickering when transitioning

### DIFF
--- a/app-android/src/main/res/values/colors.xml
+++ b/app-android/src/main/res/values/colors.xml
@@ -7,5 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="black30">#4D000000</color>
+    <color name="neutralKeyColor10">#FF191C1A</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app-android/src/main/res/values/themes.xml
+++ b/app-android/src/main/res/values/themes.xml
@@ -3,6 +3,7 @@
 
     <style name="Platform.Theme.DroidKaigi" parent="Theme.Material3.DayNight">
         <item name="android:statusBarColor">@color/black30</item>
+        <item name="android:colorBackground">@color/neutralKeyColor10</item>
     </style>
 
     <style name="Theme.DroidKaigi" parent="Platform.Theme.DroidKaigi">


### PR DESCRIPTION
## Issue
- close #355

## Overview (Required)
- Set neutral key color 10(#FF191C1A) to `android:colorBackground` in theme.xml
- According to the [Material3 document](https://m3.material.io/libraries/mdc-android/color-theming), the Android attribute corresponding to Compose color theme `Background` is `android:colorBackground `

## Further note

In not dark mode, the default value of `colorBackground` is set to `@color/m3_sys_color_light_background`(#fffffbfe) in `Theme.Material3.DayNight`. Additionally, `android:windowBackground` is set to the value of `android:colorBackground`.
Therefore, the background color is also changed when the application is launched.

I think this is the right change. Feel free to tell me if you have any problems 👍🏻

## Links
- https://m3.material.io/libraries/mdc-android/color-theming
- https://developer.android.com/reference/android/R.attr#colorBackground
- https://developer.android.com/reference/android/R.attr#windowBackground
- https://developer.android.com/develop/ui/views/theming/darktheme?hl=en#launch-screens

## Screenshot
Before | After
:--: | :--:
<video src="https://user-images.githubusercontent.com/7961496/189492024-6a501cde-976c-42dc-9107-bf31a97d1214.mp4"> | <video src="https://user-images.githubusercontent.com/7961496/189492032-05f2b6d8-392a-4512-9e64-eaf88c44daeb.mp4">

## Idea

If you watch the video, you can see that the background in `ic_launcher_background.xml` and `android:windowBackground` are different.
I thought it might be good to make them the same. I did not change this at this pull request.