### PR TITLE
[iOS] Apply room colors to the timetable items

### DIFF
--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/blue.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/blue.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB5",
+          "green" : "0x80",
+          "red" : "0x18"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/purple.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/purple.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB1",
+          "green" : "0x72",
+          "red" : "0x8A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/TimetableFeature/Extension/TimetableRoom.swift
+++ b/app-ios/Sources/TimetableFeature/Extension/TimetableRoom.swift
@@ -1,0 +1,15 @@
+import appioscombined
+import SwiftUI
+import Theme
+
+extension TimetableRoom {
+    var roomColor: Color {
+        switch name.enTitle {
+        case "App Bar": return AssetColors.pink.swiftUIColor
+        case "Backdrop": return AssetColors.orange.swiftUIColor
+        case "Cards": return AssetColors.blue.swiftUIColor
+        case "Dialogs": return AssetColors.purple.swiftUIColor
+        default: return AssetColors.pink.swiftUIColor
+        }
+    }
+}

--- a/app-ios/Sources/TimetableFeature/TimetableItemView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableItemView.swift
@@ -27,8 +27,12 @@ public struct TimetableItemView: View {
         }
         .padding(8)
         .frame(maxHeight: .infinity, alignment: .top)
-        .background(AssetColors.pink.swiftUIColor)
+        .background(item.room.roomColor.opacity(0.2))
         .cornerRadius(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(item.room.roomColor, lineWidth: 2)
+        )
     }
 }
 


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR applies room colors to the timetable items
  - The favorite style has not been implemented

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5673994/189496936-af2b00b5-e58e-4314-a7b9-b09803172a4f.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5673994/189496953-d8c6ed30-1478-4f20-8160-3b60f97b6230.png" width="300" />
