### PR TITLE
[iOS] explicit running thread when collecting coroutine flow

### DIFF
--- a/app-ios/Sources/Model/Extension/Kotlinx_coroutines_coreFlow.swift
+++ b/app-ios/Sources/Model/Extension/Kotlinx_coroutines_coreFlow.swift
@@ -18,15 +18,17 @@ class FlowCollector<T>: Kotlinx_coroutines_coreFlowCollector {
 public extension Kotlinx_coroutines_coreFlow {
     func stream<T>() -> AsyncThrowingStream<T, Error> {
         return AsyncThrowingStream { [weak self] continuation in
-            self?.collect(collector: FlowCollector<T>(callback: { value in
-                continuation.yield(value)
-            }), completionHandler: { error in
-                if let error = error {
-                    continuation.finish(throwing: error)
-                } else {
-                    continuation.finish()
-                }
-            })
+            DispatchQueue.main.async {
+                self?.collect(collector: FlowCollector<T>(callback: { value in
+                    continuation.yield(value)
+                }), completionHandler: { error in
+                    if let error = error {
+                        continuation.finish(throwing: error)
+                    } else {
+                        continuation.finish()
+                    }
+                })
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue
- close nothing

## Overview (Required)
- iOS app crash when launching

```log
2022-09-11 15:28:47.204205+0900 DroidKaigi2022[17747:5918236] *** Terminating app due to uncaught exception 'NSGenericException', reason: 'Calling Kotlin suspend functions from Swift/Objective-C is currently supported only on main thread'
```

- I put `DispatcheQueue.main` to explicit running thread
- I don't know what is the best, so please tell me if more beautiful deal

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
