### PR TITLE
Enable Kotlin Explicit API Mode (Warning)

### DIFF
--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2022.core.data"
 
 kotlin {
+    explicitApiWarning()
+
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/core-designsystem/build.gradle.kts
+++ b/core-designsystem/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2022.core.designsystem"
 
 kotlin {
+    explicitApiWarning()
+
     sourceSets {
         val commonMain by getting {
         }

--- a/core-model/build.gradle.kts
+++ b/core-model/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2022.core.model"
 
 kotlin {
+    explicitApiWarning()
+
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 
 android.namespace = "io.github.droidkaigi.confsched2022.template.core.testing"
 
+kotlin {
+    explicitApiWarning()
+}
+
 dependencies {
     api(projects.coreModel)
     api(projects.coreData)

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -8,10 +8,9 @@ plugins {
 }
 
 android.namespace = "io.github.droidkaigi.confsched2022.template.core.testing"
-
-kotlin {
-    explicitApiWarning()
-}
+android.kotlinOptions.freeCompilerArgs = listOf(
+    "-Xexplicit-api=warning",
+)
 
 dependencies {
     api(projects.coreModel)

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 
 android.namespace = "io.github.droidkaigi.confsched2022.template.core.ui"
 
+kotlin {
+    explicitApiWarning()
+}
+
 dependencies {
     implementation(libs.accompanistPager)
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -8,10 +8,9 @@ plugins {
 }
 
 android.namespace = "io.github.droidkaigi.confsched2022.template.core.ui"
-
-kotlin {
-    explicitApiWarning()
-}
+android.kotlinOptions.freeCompilerArgs = listOf(
+    "-Xexplicit-api=warning",
+)
 
 dependencies {
     implementation(libs.accompanistPager)

--- a/core-zipline/build.gradle.kts
+++ b/core-zipline/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2022.core.zipline"
 
 kotlin {
+    explicitApiWarning()
+
     js {
         browser()
         binaries.executable()


### PR DESCRIPTION
## Issue
- close #279

## Overview (Required)
- Kotlin Explicit API Mode warnings will display when editing core-xxx modules.

## Links
- [Kotlin Explicit API mode](https://github.com/Kotlin/KEEP/blob/master/proposals/explicit-api-mode.md)

## Screenshot
Before | After
:--: | :--:
<img width="300" alt="before" src="https://user-images.githubusercontent.com/100664523/189522128-55a05bd7-09b4-4acd-a8ac-a1efb4fa5013.png"> | <img width="300" alt="after" src="https://user-images.githubusercontent.com/100664523/189522137-ca2861cd-3e3f-4f40-be2d-325b9f01111b.png">
