### PR TITLE
Add 1dp start padding and 1dp end padding to TimetableItem #368

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -216,6 +216,7 @@ fun Timetable(
                         isFavorited = isFavorited,
                         verticalScale = timetableState.screenScaleState.verticalScale,
                         modifier = Modifier
+                            .padding(start = 1.dp, end = 1.dp)
                             .clickable(
                                 onClick = { onTimetableClick(timetableItem.id) }
                             ),


### PR DESCRIPTION
## Issue
- close #368 

## Overview (Required)
- Add 1dp start padding and 1dp end padding to TimetableItem

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1386930/189521861-a6173da2-739a-4ad9-80ba-0e958b4ab108.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7196624/189536752-7d504095-ca55-4a95-b5cf-2dcffb6a7681.png" width="300" />
