### PR TITLE
apply timetable color when session is favorited

### DIFF
--- a/app-ios/Sources/Model/TimetableItemType.swift
+++ b/app-ios/Sources/Model/TimetableItemType.swift
@@ -1,13 +1,13 @@
 import appioscombined
 
 public enum TimetableItemType: Identifiable, Equatable {
-    case general(TimetableItem, Int)
+    case general(TimetableItemWithFavorite, Int)
     case spacing(Int)
 
     public var id: String {
         switch self {
         case let .general(item, _):
-            return item.id.value
+            return item.timetableItem.id.value
         case .spacing:
             return UUID().uuidString
         }

--- a/app-ios/Sources/TimetableFeature/Content/SheetView.swift
+++ b/app-ios/Sources/TimetableFeature/Content/SheetView.swift
@@ -17,23 +17,22 @@ struct TimetableSheetView: View {
             self.hours = timetable.hours
             self.roomTimetableItems = Set(timetable.timetableItems.map(\.room))
                 .map { room in
-
-                    var items = timetable.timetableItems
-                        .filter {
-                            $0.room == room
+                    var items = timetable.contents
+                        .filter { itemWithFavorite in
+                            itemWithFavorite.timetableItem.room == room
                         }
                         .reduce([TimetableItemType]()) { result, item in
                             var result = result
                             let lastItem = result.last
-                            if case .general(let lItem, _) = lastItem, lItem.endsAt != item.startsAt {
+                            if case .general(let lItem, _) = lastItem, lItem.timetableItem.endsAt != item.timetableItem.startsAt {
                                 result.append(.spacing(calculateMinute(
-                                    startSeconds: Int(lItem.endsAt.epochSeconds),
-                                    endSeconds: Int(item.startsAt.epochSeconds)
+                                    startSeconds: Int(lItem.timetableItem.endsAt.epochSeconds),
+                                    endSeconds: Int(item.timetableItem.startsAt.epochSeconds)
                                 )))
                             }
                             let minute = calculateMinute(
-                                startSeconds: Int(item.startsAt.epochSeconds),
-                                endSeconds: Int(item.endsAt.epochSeconds)
+                                startSeconds: Int(item.timetableItem.startsAt.epochSeconds),
+                                endSeconds: Int(item.timetableItem.endsAt.epochSeconds)
                             )
                             result.append(
                                 TimetableItemType.general(
@@ -45,8 +44,8 @@ struct TimetableSheetView: View {
                             return result
                         }
                     if case let .general(firstItem, _) = items.first {
-                        let hour = Calendar.current.component(.hour, from: firstItem.startsAt.toDate())
-                        let minute = Calendar.current.component(.minute, from: firstItem.startsAt.toDate())
+                        let hour = Calendar.current.component(.hour, from: firstItem.timetableItem.startsAt.toDate())
+                        let minute = Calendar.current.component(.minute, from: firstItem.timetableItem.startsAt.toDate())
                         let firstSpacingItem: TimetableItemType = .spacing(minute + max(hour - timetable.hours.first!, 0) * 60)
                         items.insert(firstSpacingItem, at: 0)
                     }

--- a/app-ios/Sources/TimetableFeature/TimetableItemView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableItemView.swift
@@ -3,21 +3,21 @@ import SwiftUI
 import Theme
 
 public struct TimetableItemView: View {
-    let item: TimetableItem
+    let item: TimetableItemWithFavorite
 
-    public init(item: TimetableItem) {
+    public init(item: TimetableItemWithFavorite) {
         self.item = item
     }
 
     public var body: some View {
         VStack(alignment: .leading) {
-            Text(item.title.jaTitle)
+            Text(item.timetableItem.title.jaTitle)
                 .frame(maxWidth: CGFloat.infinity, alignment: .topLeading)
                 .font(Font.system(size: 16, weight: .bold, design: .default))
                 .foregroundColor(AssetColors.white.swiftUIColor)
             Spacer()
                 .frame(height: 8)
-            Text("\((item.endsAt.epochSeconds - item.startsAt.epochSeconds) / 60)min")
+            Text("\((item.timetableItem.endsAt.epochSeconds - item.timetableItem.startsAt.epochSeconds) / 60)min")
                 .font(Font.system(size: 12, weight: .semibold, design: .default))
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
@@ -27,11 +27,11 @@ public struct TimetableItemView: View {
         }
         .padding(8)
         .frame(maxHeight: .infinity, alignment: .top)
-        .background(item.room.roomColor.opacity(0.2))
+        .background(item.isFavorited ? item.timetableItem.room.roomColor : item.timetableItem.room.roomColor.opacity(0.2))
         .cornerRadius(16)
         .overlay(
             RoundedRectangle(cornerRadius: 16)
-                .strokeBorder(item.room.roomColor, lineWidth: 2)
+                .strokeBorder(item.timetableItem.room.roomColor, lineWidth: 2)
         )
     }
 }
@@ -40,7 +40,7 @@ public struct TimetableItemView: View {
 struct TimetableItemView_Previews: PreviewProvider {
     static var previews: some View {
         TimetableItemView(
-            item: Timetable.companion.fake().timetableItems.first!
+            item: TimetableItemWithFavorite.companion.fake()
         )
         .previewLayout(.fixed(width: 200, height: 160))
     }


### PR DESCRIPTION
## Issue
- close #379

## Overview (Required)
- replaced session item to item`withFavorite`
- remove opacity when session is favorited

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/32740480/189542664-2762f23b-683f-4b9b-97a2-fd57199fbad8.png" width="300" /> | <img src="https://user-images.githubusercontent.com/32740480/189542624-f27b5f23-3258-44b9-a068-31b0466428da.png" width="300" />
