### PR TITLE
[iOS] Disallow header comments

### DIFF
--- a/app-ios/.swiftlint.yml
+++ b/app-ios/.swiftlint.yml
@@ -3,8 +3,15 @@ disabled_rules:
   - type_name
   - trailing_comma
 
+opt_in_rules:
+  - file_header
+
 excluded:
   - .build
 
 identifier_name:
   min_length: 2
+
+file_header:
+  severity: error
+  forbidden_pattern: ^(?!// Workaround:)


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR enables the `file_header` rule to disallow header comments except workaround comments.

## Links
- https://realm.github.io/SwiftLint/file_header.html

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
