### PR TITLE
[iOS] Use @MainActor instead of DispatchQueue.main

### DIFF
--- a/app-ios/Sources/Model/Extension/Kotlinx_coroutines_coreFlow.swift
+++ b/app-ios/Sources/Model/Extension/Kotlinx_coroutines_coreFlow.swift
@@ -16,19 +16,19 @@ class FlowCollector<T>: Kotlinx_coroutines_coreFlowCollector {
 }
 
 public extension Kotlinx_coroutines_coreFlow {
+    // Note: Calling Kotlin suspend functions from Swift/Objective-C is currently supported only on main thread
+    @MainActor
     func stream<T>() -> AsyncThrowingStream<T, Error> {
         return AsyncThrowingStream { [weak self] continuation in
-            DispatchQueue.main.async {
-                self?.collect(collector: FlowCollector<T>(callback: { value in
-                    continuation.yield(value)
-                }), completionHandler: { error in
-                    if let error = error {
-                        continuation.finish(throwing: error)
-                    } else {
-                        continuation.finish()
-                    }
-                })
-            }
+            self?.collect(collector: FlowCollector<T>(callback: { value in
+                continuation.yield(value)
+            }), completionHandler: { error in
+                if let error = error {
+                    continuation.finish(throwing: error)
+                } else {
+                    continuation.finish()
+                }
+            })
         }
     }
 }

--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -36,7 +36,7 @@ public struct TimetableEnvironment {
 public let timetableReducer = Reducer<TimetableState, TimetableAction, TimetableEnvironment> { state, action, environment in
     switch action {
     case .refresh:
-        return .run { subscriber in
+        return .run { @MainActor subscriber in
             for try await result: DroidKaigiSchedule in environment.sessionsRepository.droidKaigiScheduleFlow().stream() {
                 await subscriber.send(
                     .refreshResponse(


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR is another idea to improve [this patch](https://github.com/DroidKaigi/conference-app-2022/pull/367)
- I suggest using `@MainActor` instead of `DispatchQueue.main`.
- No crashes have occurred, but there may yet be a better way 😄

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
