### PR TITLE
Improve session list item accessibility

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -38,9 +37,7 @@ fun SessionListItem(
     val roomName = timetableItem.room.name
     val roomColor = Color(TimetableItemColor.colorOfRoomName(enName = roomName.enTitle))
     Row(
-        modifier = modifier
-            .fillMaxSize()
-            .semantics { contentDescription = "isFavorited$isFavorited" },
+        modifier = modifier.fillMaxSize(),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Column(modifier = Modifier.weight(1F)) {

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTag
@@ -60,7 +61,11 @@ fun SessionListItem(
             }
         }
         IconButton(
-            modifier = Modifier.testTag("favorite"),
+            modifier = Modifier
+                .testTag("favorite")
+                .semantics {
+                    stateDescription = if (isFavorited) "ON" else "OFF"
+                },
             onClick = { onFavoriteClick(timetableItem.id, isFavorited) }
         ) {
             Icon(
@@ -71,7 +76,7 @@ fun SessionListItem(
                         drawable.ic_bookmark
                     }
                 ),
-                contentDescription = "bookmark icon",
+                contentDescription = "favorite",
             )
         }
     }

--- a/feature-sessions/src/test/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionScreenRobot.kt
+++ b/feature-sessions/src/test/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionScreenRobot.kt
@@ -3,8 +3,7 @@ package io.github.droidkaigi.confsched2022.feature.sessions
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasAnySibling
-import androidx.compose.ui.test.hasContentDescription
-import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -44,7 +43,7 @@ class SessionScreenRobot @Inject constructor() {
             .onFavorite(
                 index
             )
-            .assert(hasParent(hasContentDescription("isFavorited$isFavorited")))
+            .assert(hasStateDescription(if (isFavorited) "ON" else "OFF"))
     }
 
     context(RobotTestRule)


### PR DESCRIPTION
## Overview (Required)
- Improvements for TalkBack
  - Remove unnecessary contentDescription from item view
  - Add stateDescription to favorite button

It's not the best, but it's easier to read.

## Screenshot
Notice the TalkBack reading at the bottom of the screenshot.
### Session item
Before | After
:--: | :--:
"isFavoritedtrue" | "[Session title] [Room name] [Minutes]"
<img src="https://user-images.githubusercontent.com/3139391/189674969-d24d9e20-05cf-4b77-96fe-a87209a2c8f5.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3139391/189675908-4519446c-4e19-47ff-8f04-0b8663aeeab0.png" width="300" />

### Favorite button
Before | After
:--: | :--:
"bookmark icon, ボタン" | "ON, favorite, ボタン"
<img src="https://user-images.githubusercontent.com/3139391/189674986-66393137-c338-4921-9cbf-a56ed514e5cc.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3139391/189676320-80de91fd-7f23-4ed7-bf1d-89c74c759fc4.png" width="300" />

## ScreenRecord
### Before
https://user-images.githubusercontent.com/3139391/189697654-9f1ba2ca-ebd0-42be-a28e-376b02f60e76.mp4
### After
https://user-images.githubusercontent.com/3139391/189697705-ce403daf-49de-4ff7-bf01-3f095a78b168.mp4