### PR TITLE
Fix contributors screen accessibility

### DIFF
--- a/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
+++ b/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
@@ -40,7 +40,7 @@ fun UsernameRow(
 
         AsyncImage(
             model = iconUrl,
-            contentDescription = username,
+            contentDescription = null,
             alignment = Alignment.Center,
             contentScale = ContentScale.Fit,
             modifier = Modifier


### PR DESCRIPTION
## Overview (Required)
- Fix TalkBack says contributors name twice.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3139391/189704672-df940d86-a3f4-49bf-8baf-37a666387199.jpg" width="300" /> | <img src="https://user-images.githubusercontent.com/3139391/189704654-bb3946db-61a6-4b0f-b090-62e243b6d004.jpg" width="300" />
