### PR TITLE
[iOS]Remove unnecessary spacing

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -72,7 +72,7 @@ public struct TimetableView: View {
     public var body: some View {
         WithViewStore(store) { viewStore in
             NavigationView {
-                VStack {
+                VStack(spacing: 0) {
                     HStack(spacing: 8) {
                         ForEach(
                             [DroidKaigi2022Day].fromKotlinArray(DroidKaigi2022Day.values())


### PR DESCRIPTION
## Issue
- close #383 

## Overview (Required)
- Set the VStack spacing to 0.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6764614/189722840-f21f64d5-faab-4cc8-9973-09784190e55f.png" width="300" alt="with_spacing" /> | <img src="https://user-images.githubusercontent.com/6764614/189722957-8e7018d2-19ec-4163-b79b-f9d92fbb9cd8.png" width="300" alt="no_spacing" />