### PR TITLE
[edge-to-edge] Draw content behind the navigation bar (partial)

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
@@ -21,6 +21,7 @@ class MainActivity : ComponentActivity() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 Color.TRANSPARENT
             } else {
+                // Make it easy to see navigation buttons for older OS versions
                 Color.argb((255 * 0.5).toInt(), 0, 0, 0)
             }
 

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
@@ -1,8 +1,8 @@
 package io.github.droidkaigi.confsched2022
 
-import android.os.Bundle
 import android.graphics.Color
 import android.os.Build
+import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2022
 
 import android.os.Bundle
 import android.graphics.Color
+import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -16,7 +17,12 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.statusBarColor = Color.TRANSPARENT
-        window.navigationBarColor = Color.TRANSPARENT
+        window.navigationBarColor =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                Color.TRANSPARENT
+            } else {
+                Color.argb((255 * 0.5).toInt(), 0, 0, 0)
+            }
 
         setContent {
             KaigiApp(calculateWindowSizeClass(this))

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2022
 
 import android.os.Bundle
+import android.graphics.Color
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -14,6 +15,8 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
 
         setContent {
             KaigiApp(calculateWindowSizeClass(this))

--- a/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiScaffold.kt
+++ b/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiScaffold.kt
@@ -1,8 +1,6 @@
 package io.github.droidkaigi.confsched2022.designsystem.components
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -16,7 +14,7 @@ fun KaigiScaffold(
     modifier: Modifier = Modifier,
     topBar: @Composable () -> Unit,
     bottomBar: @Composable () -> Unit = {},
-    content: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
 ) {
     Scaffold(
         modifier = modifier,
@@ -27,13 +25,7 @@ fun KaigiScaffold(
             bottomBar()
         }
     ) { insetPadding ->
-        Row(
-            Modifier
-                .fillMaxSize()
-                .padding(insetPadding)
-        ) {
-            content()
-        }
+        content(insetPadding)
     }
 }
 

--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
@@ -89,9 +89,11 @@ fun About(
                 },
             )
         }
-    ) {
+    ) { innerPadding ->
         Column(
-            modifier = modifier.verticalScroll(rememberScrollState())
+            modifier = modifier
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
         ) {
             Column(
                 modifier = Modifier

--- a/feature-announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcement.kt
+++ b/feature-announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcement.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.feature.announcement
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,11 +39,12 @@ fun Announcement(
                 },
             )
         }
-    ) {
+    ) { innerPadding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
+                .background(MaterialTheme.colorScheme.background)
+                .padding(innerPadding),
             contentAlignment = Alignment.Center
         ) {
             Text(

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.feature.contributors
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
@@ -56,28 +57,30 @@ fun Contributors(
                 },
             )
         }
-    ) {
-        when (uiModel.state) {
-            is Error -> TODO()
-            Loading -> Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
-            is Success -> {
-                val contributors = uiModel.state.value
-
-                LazyColumn(
-                    modifier = modifier.fillMaxWidth()
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            when (uiModel.state) {
+                is Error -> TODO()
+                Loading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
                 ) {
-                    items(items = contributors, key = { it.id }) { contributor ->
-                        UsernameRow(
-                            username = contributor.username,
-                            profileUrl = contributor.profileUrl,
-                            iconUrl = contributor.iconUrl,
-                            onLinkClick = onLinkClick
-                        )
+                    CircularProgressIndicator()
+                }
+                is Success -> {
+                    val contributors = uiModel.state.value
+
+                    LazyColumn(
+                        modifier = modifier.fillMaxWidth()
+                    ) {
+                        items(items = contributors, key = { it.id }) { contributor ->
+                            UsernameRow(
+                                username = contributor.username,
+                                profileUrl = contributor.profileUrl,
+                                iconUrl = contributor.iconUrl,
+                                onLinkClick = onLinkClick
+                            )
+                        }
                     }
                 }
             }

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -80,8 +80,10 @@ private fun SearchScreen(
     KaigiScaffold(
         modifier = modifier,
         topBar = {},
-        content = {
-            Column {
+        content = { innerPadding ->
+            Column(
+                modifier = Modifier.padding(innerPadding)
+            ) {
                 when (uiModel.state) {
                     is Error -> TODO()
                     is Success -> {

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -170,47 +170,49 @@ fun SessionDetailScreen(
                 )
             }
         },
-    ) {
-        when (uiState) {
-            is Error -> TODO()
-            Loading ->
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            is Success -> {
-                val (item, _) = uiState.value
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            when (uiState) {
+                is Error -> TODO()
+                Loading ->
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                is Success -> {
+                    val (item, _) = uiState.value
 
-                Column(
-                    modifier = modifier
-                        .verticalScroll(rememberScrollState())
-                        .padding(horizontal = 16.dp)
-                ) {
-                    SessionDetailSessionInfo(
-                        title = item.title.currentLangTitle,
-                        startsAt = item.startsAt,
-                        endsAt = item.endsAt,
-                        room = item.room,
-                        category = item.category,
-                        language = item.language,
-                        levels = item.levels,
-                    )
-
-                    if (item is Session)
-                        SessionDetailDescription(
-                            description = item.description
+                    Column(
+                        modifier = modifier
+                            .verticalScroll(rememberScrollState())
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        SessionDetailSessionInfo(
+                            title = item.title.currentLangTitle,
+                            startsAt = item.startsAt,
+                            endsAt = item.endsAt,
+                            room = item.room,
+                            category = item.category,
+                            language = item.language,
+                            levels = item.levels,
                         )
 
-                    SessionDetailTargetAudience(
-                        targetAudience = item.targetAudience
-                    )
+                        if (item is Session)
+                            SessionDetailDescription(
+                                description = item.description
+                            )
 
-                    if (item is Session)
-                        SessionDetailSpeakers(
-                            speakers = item.speakers,
+                        SessionDetailTargetAudience(
+                            targetAudience = item.targetAudience
                         )
-                    SessionDetailAssets(
-                        asset = item.asset
-                    )
+
+                        if (item is Session)
+                            SessionDetailSpeakers(
+                                speakers = item.speakers,
+                            )
+                        SessionDetailAssets(
+                            asset = item.asset
+                        )
+                    }
                 }
             }
         }

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -128,8 +128,12 @@ fun Sessions(
                 onToggleTimetableClick
             )
         }
-    ) {
-        Column(modifier = Modifier.padding(top = 4.dp)) {
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(top = 4.dp)
+                .padding(innerPadding)
+        ) {
             when (scheduleState) {
                 is Error -> {
                     scheduleState.value?.printStackTrace()

--- a/feature-setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
+++ b/feature-setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
@@ -49,9 +49,11 @@ fun Setting(
                 },
             )
         }
-    ) {
+    ) { innerPadding ->
         Column(
-            modifier = Modifier.padding(start = 28.dp, top = 40.dp, end = 28.dp),
+            modifier = Modifier
+                .padding(start = 28.dp, top = 40.dp, end = 28.dp)
+                .padding(innerPadding),
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.Start
         ) {

--- a/feature-sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
+++ b/feature-sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2022.feature.sponsors
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -41,8 +42,13 @@ fun Sponsors(
                 }
             )
         }
-    ) {
-        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
             Text(text = "Coming Soon...")
         }
     }

--- a/feature-staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
+++ b/feature-staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.feature.staff
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
@@ -56,28 +57,30 @@ fun Staff(
                 },
             )
         }
-    ) {
-        when (uiModel.state) {
-            is Error -> TODO()
-            is Loading -> Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
-            is Success -> {
-                val staff = uiModel.state.value
-
-                LazyColumn(
-                    modifier = modifier.fillMaxWidth()
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            when (uiModel.state) {
+                is Error -> TODO()
+                is Loading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
                 ) {
-                    items(items = staff, key = { it.id }) { staff ->
-                        UsernameRow(
-                            username = staff.username,
-                            profileUrl = staff.profileUrl,
-                            iconUrl = staff.iconUrl,
-                            onLinkClick = onLinkClick
-                        )
+                    CircularProgressIndicator()
+                }
+                is Success -> {
+                    val staff = uiModel.state.value
+
+                    LazyColumn(
+                        modifier = modifier.fillMaxWidth()
+                    ) {
+                        items(items = staff, key = { it.id }) { staff ->
+                            UsernameRow(
+                                username = staff.username,
+                                profileUrl = staff.profileUrl,
+                                iconUrl = staff.iconUrl,
+                                onLinkClick = onLinkClick
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Issue
- #408

## Overview (Required)
- Allow content to be drawn behind the navigation bar.
- Change `KaigiScaffold` to pass inner padding to child Composable.
- Since there is no automatic coloring of navigation bar under android 10, specify a translucent color for the navigation bar.
- Support other than the About screen is partial.

## TODO
- Fully support other screens.

## Screenshot
Before | After
:--:|:--:
![Screenshot_20220913_192848](https://user-images.githubusercontent.com/13435109/189878853-7938988d-10ba-40a5-80b0-fed6b49333d2.png)|![Screenshot_20220913_192555](https://user-images.githubusercontent.com/13435109/189878890-967f567e-c5eb-4934-8817-ddf5e0451f8c.png)
![Screenshot_20220913_192912](https://user-images.githubusercontent.com/13435109/189878862-0b35dfe6-6d55-41d4-987a-b55cbd96fcde.png)|![Screenshot_20220913_192451](https://user-images.githubusercontent.com/13435109/189878885-e15eac3f-bb18-4ec9-9a37-b341874bff00.png)

