### PR TITLE
Unify all app bar colors

### DIFF
--- a/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiTopAppBar.kt
+++ b/core-designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiTopAppBar.kt
@@ -26,7 +26,7 @@ fun KaigiTopAppBar(
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     modifier: Modifier = Modifier,
-    elevation: Dp = 0.dp,
+    elevation: Dp = 2.dp,
     title: (@Composable RowScope.() -> Unit),
     trailingIcons: (@Composable RowScope.() -> Unit)? = null,
 ) {

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -324,7 +324,6 @@ fun SessionsTopBar(
         KaigiTopAppBar(
             showNavigationIcon = showNavigationIcon,
             onNavigationIconClick = onNavigationIconClick,
-            elevation = 2.dp,
             title = {
                 Image(
                     modifier = Modifier.size(30.dp),


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2022/issues/405

## Overview (Required)

Unify all app bar colors.

## Screenshot

<img src="https://user-images.githubusercontent.com/25548003/189888182-d2087e57-71fe-42d7-8dc7-c29d4535cba1.png" width="300" />


