### PR TITLE
show keyboard input by opening search screen #415

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -29,13 +29,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -112,6 +116,10 @@ private fun SearchTextField(
     onSearchWordChange: (String) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -122,7 +130,8 @@ private fun SearchTextField(
             value = searchWord,
             modifier = Modifier
                 .fillMaxWidth(fraction = 0.9F)
-                .background(color = MaterialTheme.colorScheme.surfaceVariant),
+                .background(color = MaterialTheme.colorScheme.surfaceVariant)
+                .focusRequester(focusRequester),
             placeholder = { Text("Search Session") },
             singleLine = true,
             keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),


### PR DESCRIPTION
## Issue
- close #415 

## Overview (Required)
- After tapping search icon, (focused to textField) and show keyboard.

## Links
- Nothing.

## Movie(webm)
[device-2022-09-13-200444.webm](https://user-images.githubusercontent.com/45124565/189887587-2fb3075e-216f-4299-9161-f0dbcbec65d1.webm)