### PR TITLE
[suggestion] :recycle: Update Set a placeholder for the speaker's image.

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -485,6 +485,7 @@ fun SessionDetailSpeakers(
                         modifier = Modifier
                             .size(60.dp)
                             .clip(CircleShape),
+                        placeholder = painterResource(R.drawable.ic_baseline_person_24),
                         contentScale = ContentScale.Fit,
                         alignment = Alignment.Center,
                         contentDescription = "Speaker Icon",

--- a/feature-sessions/src/main/res/drawable/ic_baseline_person_24.xml
+++ b/feature-sessions/src/main/res/drawable/ic_baseline_person_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#C0C9C1"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- Since nothing is displayed until the speaker's image is loaded, I set a placeholder.
  - This is only a temporary image and can be replaced with a better image or loading display if available.

## Links
- Nothing.

## Movie

https://user-images.githubusercontent.com/13657682/189915788-9eae34f9-7db9-4aaf-9ce9-cd4c1e33f16a.mp4

https://user-images.githubusercontent.com/13657682/189915742-f35f1a3a-26af-457e-9145-29dba7aafbd3.mp4