### PR TITLE
[iOS] fix: Incorrect navigation style in iPad (TimetableView)

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -136,6 +136,7 @@ public struct TimetableView: View {
                 }
                 .navigationBarTitleDisplayMode(.inline)
             }
+            .navigationViewStyle(.stack)
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #423 

## Overview (Required)
- Set `.navigationViewStyle(.stack)` to NavigationView in TimetableView

## Links
-

## Screenshot
Used `iPad(9th generation)`

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/50735539/189948563-4650e42d-c24b-4fbe-af37-d92f3bab2b08.png" width="300" /> | <img src="https://user-images.githubusercontent.com/50735539/189948838-9357bb22-e22f-4fe2-8e34-e38391a94af3.png" width="300" />
<img src="https://user-images.githubusercontent.com/50735539/189948585-a50b608c-8a53-456a-9582-a16440d004dc.png" width="300" />  |
