### PR TITLE
Use round ripple to about icons

### DIFF
--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -23,6 +22,7 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Train
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -249,14 +249,13 @@ private fun ExternalServiceImage(
     serviceType: ExternalServices,
     onClick: () -> Unit,
 ) {
-    Image(
-        modifier = Modifier
-            .clickable(onClick = onClick)
-            .padding(12.dp)
-            .size(24.dp),
-        imageVector = ImageVector.vectorResource(id = serviceType.iconRes),
-        contentDescription = serviceType.contentDescription,
-    )
+    IconButton(onClick = onClick) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = serviceType.iconRes),
+            contentDescription = serviceType.contentDescription,
+            tint = Color.Unspecified,
+        )
+    }
 }
 
 private fun versionName(context: Context) = runCatching {


### PR DESCRIPTION
## Issue
- close #373 

## Overview (Required)
-  I have modified the icon ripple shape on the About screen to be round.
 Implemented using IconButton and Icon as well as navigaton icon.

## Screenshot
Before | After
:--: | :--:
![ripple-square](https://user-images.githubusercontent.com/16633277/189961873-74d4ff43-60e0-4147-9c4e-2c9578d92240.png) | ![ripple-icon-rounded](https://user-images.githubusercontent.com/16633277/189962400-18bb8f9c-4c95-4667-b2b7-382092acc3c5.png)



<img src="" width="300" /> | <img src="" width="300" />
