### PR TITLE
Fix the room colors for the timetable items

### DIFF
--- a/core-designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/theme/TimetableItemColor.kt
+++ b/core-designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/theme/TimetableItemColor.kt
@@ -3,8 +3,9 @@ package io.github.droidkaigi.confsched2022.designsystem.theme
 enum class TimetableItemColor(val roomName: String, val color: Long) {
     AppBar(roomName = "App Bar", color = 0xFFFE8299),
     BackDrop(roomName = "Backdrop", color = 0xFFFF592F),
-    Cards(roomName = "Cards", color = 0xFF1880B5),
-    Dialogs(roomName = "Dialogs", color = 0xFF8A72B1);
+    Cards(roomName = "Cards", color = 0xFFFFAF01),
+    Dialogs(roomName = "Dialogs", color = 0xFF069CCF),
+    Online(roomName = "Online", color = 0xFFA58CDF);
 
     companion object {
         fun colorOfRoomName(enName: String): Long {


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR fixes the room colors for the timetable items as follows:
<img src="https://user-images.githubusercontent.com/5673994/189986763-22483413-fd7c-4672-906f-79737e8164bf.png" width="300" />

## Links
- [App Design](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5673994/189986458-92d740ab-b7e0-4fbc-b1f8-ea7cf781fb9a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5673994/189986512-b77ebdf5-c802-459c-acaf-5db68c374fe7.png" width="300" />