### PR TITLE
[Foundation] Add string for announcement and contributor

### DIFF
--- a/core-model/src/commonMain/resources/MR/base/strings.xml
+++ b/core-model/src/commonMain/resources/MR/base/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <resources>
+    <!-- About -->
     <string name="about_top_app_bar_title">DroidKaigiとは</string>
     <string name="about_title">What is DroidKaigi?</string>
     <string name="about_description">DroidKaigiはエンジニアが主役のAndroidカンファレンスです。\nAndroid技術情報の共有とコミュニケーションを目的に、2022年10月5日(水)〜7日(金)の3日間開催します。</string>
@@ -8,4 +9,10 @@
     <string name="about_privacy">プライバシーポリシー</string>
     <string name="about_license">ライセンス</string>
     <string name="about_app_version">アプリバーション</string>
+
+    <!-- Announcement -->
+    <string name="announcement_top_app_bar_title">お知らせ</string>
+
+    <!-- Contributors -->
+    <string name="contributors_top_app_bar_title">コントリビューター</string>
 </resources>

--- a/core-model/src/commonMain/resources/MR/en/strings.xml
+++ b/core-model/src/commonMain/resources/MR/en/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <resources>
+    <!-- About -->
     <string name="about_top_app_bar_title">About DroidKaigi</string>
     <string name="about_title">What is DroidKaigi?</string>
     <string name="about_description">DroidKaigi is a conference tailored for Android developers. It\'s scheduled to take place on the 5 to 7 of October 2022.</string>
@@ -8,4 +9,10 @@
     <string name="about_privacy">Privacy Policy</string>
     <string name="about_license">License</string>
     <string name="about_app_version">App Version</string>
+
+    <!-- Announcement -->
+    <string name="announcement_top_app_bar_title">Announcement</string>
+
+    <!-- Contributors -->
+    <string name="contributors_top_app_bar_title">Contributors</string>
 </resources>

--- a/feature-announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcement.kt
+++ b/feature-announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcement.kt
@@ -9,10 +9,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
-import io.github.droidkaigi.confsched2022.feature.announcement.R.string
+import io.github.droidkaigi.confsched2022.strings.Strings
 
 @Composable
 fun AnnouncementScreenRoot(
@@ -34,7 +34,7 @@ fun Announcement(
                 onNavigationIconClick = onNavigationIconClick,
                 title = {
                     Text(
-                        text = stringResource(id = string.announcement_top_app_bar_title),
+                        text = stringResource(Strings.announcement_top_app_bar_title),
                     )
                 },
             )

--- a/feature-announcement/src/main/res/values-en/strings.xml
+++ b/feature-announcement/src/main/res/values-en/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="announcement_top_app_bar_title">Announcement</string>
-</resources>

--- a/feature-announcement/src/main/res/values/strings.xml
+++ b/feature-announcement/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="announcement_top_app_bar_title">お知らせ</string>
-</resources>

--- a/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
+++ b/feature-announcement/src/test/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementScreenRobot.kt
@@ -2,7 +2,7 @@ package io.github.droidkaigi.confsched2022.feature.announcement
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
-import io.github.droidkaigi.confsched2022.feature.announcement.R.string
+import io.github.droidkaigi.confsched2022.strings.Strings
 import io.github.droidkaigi.confsched2022.testing.RobotTestRule
 import javax.inject.Inject
 
@@ -12,7 +12,7 @@ class AnnouncementScreenRobot @Inject constructor() {
     fun checkAnnouncementTitleVisible() {
         // TODO: Language-specific testing
         val appBarTitleText = composeTestRule.activity
-            .getString(string.announcement_top_app_bar_title)
+            .getString(Strings.announcement_top_app_bar_title.resourceId)
         composeTestRule.onNodeWithText(appBarTitleText).assertIsDisplayed()
     }
 

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -12,15 +12,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.components.UsernameRow
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2022.model.Contributor
 import io.github.droidkaigi.confsched2022.model.fakes
+import io.github.droidkaigi.confsched2022.strings.Strings
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Error
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Loading
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Success
@@ -52,7 +53,7 @@ fun Contributors(
                 onNavigationIconClick = onNavigationIconClick,
                 title = {
                     Text(
-                        text = stringResource(id = R.string.contributors_top_app_bar_title),
+                        text = stringResource(Strings.contributors_top_app_bar_title),
                     )
                 },
             )

--- a/feature-contributors/src/main/res/values-en/strings.xml
+++ b/feature-contributors/src/main/res/values-en/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="contributors_top_app_bar_title">Contributors</string>
-</resources>

--- a/feature-contributors/src/main/res/values/strings.xml
+++ b/feature-contributors/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="contributors_top_app_bar_title">Contributors</string>
-</resources>


### PR DESCRIPTION
## Issue
- N/A continuation from #387 

## Overview (Required)
I have migrated 2 more screens into this Announcement and Contributor.

## Links

## Screenshot

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/4669517/190042049-087ca6b8-3f99-4bbf-a63f-78f1de0051a4.png" width="300" />

In 日本語
<img src="https://user-images.githubusercontent.com/4669517/190042046-d3bcf8d9-9959-44c4-9ce8-442767ae290d.png" width="300" />

In English

<img src="https://user-images.githubusercontent.com/4669517/190056810-fda48669-9b66-4447-a2b1-53a4b45e3250.png" width="300" />
