### PR TITLE
Enabled ProGuard/R8 code shrink for release builds

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -33,6 +33,13 @@ android {
         }
     }
     buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
         debug {
             signingConfig = null
         }


### PR DESCRIPTION
## Issue
- close #138, #374

## Overview (Required)
- Enabled R8 by setting `minifyEnabled` to `true`
- Actually just cherry-picked a commit from #225 by @Nthily
  - R8 seemd to prevent loading sessions from working when the fix is tried last week (https://github.com/DroidKaigi/conference-app-2022/pull/225#issuecomment-1237842113) but it looks working now without any issue
    - I'm not sure what resolved the issue but possibly some changes about Zipline changed the situation...? 🤔

### APK sizes

- Without ProGurad/R8: 22MB
  ```sh
  $ git switch main
  Switched to branch 'main'
  Your branch is up to date with 'origin/main'.
  
  $ ./gradlew clean assembleDevRelease
  ...
  
  $ find . -name '*.apk' | xargs ls -lh
  -rw-r--r--  1 tkanda  staff    22M Sep 14 16:57 ./app-android/build/outputs/apk/dev/release/app-android-dev-release.apk
  ```
- With ProGuard/R8: 12MB
  ```sh
  $ git switch enable-proguard
  Switched to branch 'enable-proguard'
  
  $ ./gradlew clean assembleDevRelease
  ...
  
  $ find . -name '*.apk' | xargs ls -lh
  -rw-r--r--  1 tkanda  staff    12M Sep 14 16:57 ./app-android/build/outputs/apk/dev/release/app-android-dev-release.apk
  ```

### Tests

No issue found while testing the app built with ProGuard/R8 on several different environments.

- Environment
  - Android Emulator (API 23, Android 6.0)
  - Android Emulator (API 33, Android Tiramisu)
  - Pixel 3a (API 31, Android 12)
- Checked behavior
  - Launch app
  - Show sessions in timetable format
  - Show sessions in list format
  - Show session details
  - Bookmark and un-bookmark sessions
  - Show About screen
  - Show Announcements screen
  - Show Floor map screen
  - Show Sponsors screen
  - Show Contributors screen
  - Jump contributor's GitHub page from Contributors screen
  - Show Settings screen

Here is a screen record capturing tests on Pixel 3a.

https://user-images.githubusercontent.com/12084705/190102995-62eda90a-f86f-427c-98e2-99b237feba8b.mp4