### PR TITLE
Apply the IME WindowInsets to the SearchScreen content.

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -8,15 +8,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -87,13 +88,11 @@ private fun SearchScreen(
     KaigiScaffold(
         modifier = modifier,
         topBar = {},
-        content = { innerPadding ->
-            val insets = WindowInsets(
-                top = innerPadding.calculateTopPadding(),
-                bottom = innerPadding.calculateBottomPadding()
-            ).union(WindowInsets.ime)
+        content = {
             Column(
-                modifier = Modifier.windowInsetsPadding(insets)
+                modifier = Modifier.windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(WindowInsetsSides.Vertical)
+                )
             ) {
                 when (uiModel.state) {
                     is Error -> TODO()

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -7,14 +7,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -84,8 +88,12 @@ private fun SearchScreen(
         modifier = modifier,
         topBar = {},
         content = { innerPadding ->
+            val insets = WindowInsets(
+                top = innerPadding.calculateTopPadding(),
+                bottom = innerPadding.calculateBottomPadding()
+            ).union(WindowInsets.ime)
             Column(
-                modifier = Modifier.padding(innerPadding)
+                modifier = Modifier.windowInsetsPadding(insets)
             ) {
                 when (uiModel.state) {
                     is Error -> TODO()


### PR DESCRIPTION
## Issue
- close #411 

## Overview (Required)
- Apply the IME WindowInsets to the SearchScreen content to make it scrollable to the bottom when the keyboard is shown.

## Screenshot
<img src="https://user-images.githubusercontent.com/17829294/190155636-9e9e7036-e8ca-4eb5-a6c9-9c88acab68eb.png" width="300" />

