### PR TITLE
[Foundation] Migrate to StringResource for Sponsor and Staff screen

### DIFF
--- a/core-model/src/commonMain/resources/MR/base/strings.xml
+++ b/core-model/src/commonMain/resources/MR/base/strings.xml
@@ -31,4 +31,9 @@
     <string name="setting_item_dark_mode">ダークモード</string>
     <string name="setting_item_language">言語設定</string>
 
+    <!-- Sponsors -->
+    <string name="sponsors_top_app_bar_title">スポンサー</string>
+
+    <!-- Staff -->
+    <string name="staff_top_app_bar_title">スタッフリスト</string>
 </resources>

--- a/core-model/src/commonMain/resources/MR/en/strings.xml
+++ b/core-model/src/commonMain/resources/MR/en/strings.xml
@@ -31,4 +31,9 @@
     <string name="setting_item_dark_mode">Dark Mode</string>
     <string name="setting_item_language">Language</string>
 
+    <!-- Sponsors -->
+    <string name="sponsors_top_app_bar_title">Sponsors</string>
+
+    <!-- Staff -->
+    <string name="staff_top_app_bar_title">Staff</string>
 </resources>

--- a/feature-sponsors/build.gradle.kts
+++ b/feature-sponsors/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2022.feature.sponsors"
 
 dependencies {
+    implementation(projects.coreUi)
     implementation(projects.coreDesignsystem)
+    implementation(projects.coreModel)
 
     implementation(libs.hiltNavigationCompose)
 }

--- a/feature-sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
+++ b/feature-sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
@@ -7,9 +7,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
+import io.github.droidkaigi.confsched2022.strings.Strings
 
 @Composable
 fun SponsorsScreenRoot(
@@ -37,7 +38,7 @@ fun Sponsors(
                 onNavigationIconClick = onNavigationIconClick,
                 title = {
                     Text(
-                        text = stringResource(id = R.string.sponsors_top_app_bar_title),
+                        text = stringResource(Strings.sponsors_top_app_bar_title),
                     )
                 }
             )

--- a/feature-sponsors/src/main/res/values-en/strings.xml
+++ b/feature-sponsors/src/main/res/values-en/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="sponsors_top_app_bar_title">Sponsors</string>
-</resources>

--- a/feature-sponsors/src/main/res/values/strings.xml
+++ b/feature-sponsors/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="sponsors_top_app_bar_title">Sponsors</string>
-</resources>

--- a/feature-staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
+++ b/feature-staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
@@ -12,15 +12,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.components.UsernameRow
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2022.model.Staff
 import io.github.droidkaigi.confsched2022.model.fakes
+import io.github.droidkaigi.confsched2022.strings.Strings
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Error
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Loading
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Success
@@ -52,7 +53,7 @@ fun Staff(
                 onNavigationIconClick = onNavigationIconClick,
                 title = {
                     Text(
-                        text = stringResource(id = R.string.staff_top_app_bar_title),
+                        text = stringResource(Strings.staff_top_app_bar_title),
                     )
                 },
             )

--- a/feature-staff/src/main/res/values-en/strings.xml
+++ b/feature-staff/src/main/res/values-en/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="staff_top_app_bar_title">Staff</string>
-</resources>

--- a/feature-staff/src/main/res/values/strings.xml
+++ b/feature-staff/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="staff_top_app_bar_title">スタッフリスト</string>
-</resources>


### PR DESCRIPTION
## Issue
- N/A, this PR is a continuation from #387, #441, and #450

## Overview (Required)
I have migrated 2 more screens into this setup Sponsor and Staff screen.

## Links
-

PS. I will have another last PR to migrate app/android into this setup as well.

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
