### PR TITLE
[edge-to-edge] Apply edge to edge into SessionsScreen

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2022.feature.sessions
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -14,11 +15,13 @@ fun SessionList(
     timetable: List<Pair<DurationTime?, TimetableItemWithFavorite>>,
     sessionsListListState: LazyListState,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
     content: @Composable (Pair<DurationTime?, TimetableItemWithFavorite>) -> Unit,
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        state = sessionsListListState
+        state = sessionsListListState,
+        contentPadding = contentPadding,
     ) {
         itemsIndexed(timetable) { _, item ->
             key(item.second.timetableItem.id.value) {

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -141,7 +142,6 @@ fun Sessions(
         Column(
             modifier = Modifier
                 .padding(top = 4.dp)
-                .padding(innerPadding)
         ) {
             when (scheduleState) {
                 is Error -> {
@@ -149,7 +149,9 @@ fun Sessions(
                     TODO()
                 }
                 Loading -> Box(
-                    modifier = modifier.fillMaxSize(),
+                    modifier = modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator()
@@ -159,6 +161,7 @@ fun Sessions(
                     val days = schedule.days
                     if (isTimetable) {
                         Timetable(
+                            modifier = Modifier.padding(innerPadding),
                             pagerState = pagerState,
                             schedule = schedule,
                             timetableListStates = pagerContentsScrollState.timetableStates,
@@ -172,7 +175,8 @@ fun Sessions(
                             schedule = schedule,
                             days = days,
                             onTimetableClick = onTimetableClick,
-                            onFavoriteClick = onFavoriteClick
+                            onFavoriteClick = onFavoriteClick,
+                            contentPadding = innerPadding,
                         )
                     }
                 }
@@ -258,8 +262,11 @@ fun SessionsList(
     days: Array<DroidKaigi2022Day>,
     onTimetableClick: (timetableItemId: TimetableItemId) -> Unit,
     onFavoriteClick: (TimetableItemId, Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues()
 ) {
     HorizontalPager(
+        modifier = modifier,
         count = days.size,
         state = pagerState
     ) { dayIndex ->
@@ -286,7 +293,8 @@ fun SessionsList(
         }
         SessionList(
             timetable = timeHeaderAndTimetableItems,
-            sessionsListListState = sessionsListListStates[dayIndex]
+            sessionsListListState = sessionsListListStates[dayIndex],
+            contentPadding = contentPadding
         ) { (timeHeader, timetableItemWithFavorite) ->
             Box(
                 modifier = Modifier

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -8,12 +8,17 @@ import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -381,7 +386,10 @@ fun SessionsTopBar(
                         color = MaterialTheme.colorScheme
                             .surfaceColorAtElevation(2.dp)
                     )
-                    .padding(16.dp),
+                    .padding(16.dp)
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
+                    ),
                 containerColor = MaterialTheme.colorScheme
                     .surfaceColorAtElevation(2.dp),
                 indicator = {

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -41,6 +43,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
@@ -161,12 +164,12 @@ fun Sessions(
                     val days = schedule.days
                     if (isTimetable) {
                         Timetable(
-                            modifier = Modifier.padding(innerPadding),
                             pagerState = pagerState,
                             schedule = schedule,
                             timetableListStates = pagerContentsScrollState.timetableStates,
                             days = days,
-                            onTimetableClick = onTimetableClick
+                            onTimetableClick = onTimetableClick,
+                            contentPadding = innerPadding,
                         )
                     } else {
                         SessionsList(
@@ -197,12 +200,13 @@ fun Sessions(
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun Timetable(
-    modifier: Modifier = Modifier,
     pagerState: PagerState,
     timetableListStates: List<TimetableState>,
     schedule: DroidKaigiSchedule,
     days: Array<DroidKaigi2022Day>,
     onTimetableClick: (TimetableItemId) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     HorizontalPager(
         count = days.size,
@@ -213,8 +217,15 @@ fun Timetable(
         val timetable = schedule.dayToTimetable[day].orEmptyContents()
         val timetableState = timetableListStates[dayIndex]
         val coroutineScope = rememberCoroutineScope()
+        val layoutDirection = LocalLayoutDirection.current
 
-        Row {
+        Row(
+            modifier = Modifier.padding(
+                top = contentPadding.calculateTopPadding(),
+                start = contentPadding.calculateStartPadding(layoutDirection),
+                end = contentPadding.calculateEndPadding(layoutDirection),
+            )
+        ) {
             Hours(
                 modifier = modifier.transformable(
                     rememberTransformableStateForScreenScale(timetableState.screenScaleState),
@@ -235,7 +246,10 @@ fun Timetable(
                 Timetable(
                     timetable = timetable,
                     timetableState = timetableState,
-                    coroutineScope,
+                    coroutineScope = coroutineScope,
+                    contentPadding = PaddingValues(
+                        bottom = contentPadding.calculateBottomPadding(),
+                    )
                 ) { timetableItem, isFavorited ->
                     TimetableItem(
                         timetableItem = timetableItem,

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -10,7 +10,11 @@ import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.gestures.forEachGesture
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.layout.LazyLayout
 import androidx.compose.foundation.lazy.layout.LazyLayoutItemProvider
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +40,7 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.ScrollAxisRange
 import androidx.compose.ui.semantics.horizontalScrollAxisRange
 import androidx.compose.ui.semantics.scrollBy
@@ -44,6 +49,7 @@ import androidx.compose.ui.semantics.verticalScrollAxisRange
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day.Day1
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day.Day2
@@ -70,6 +76,7 @@ fun Timetable(
     timetableState: TimetableState,
     coroutineScope: CoroutineScope,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
     content: @Composable (TimetableItem, Boolean) -> Unit,
 ) {
     val itemProvider = itemProvider({ timetable.timetableItems.size }) { index ->
@@ -92,9 +99,15 @@ fun Timetable(
     val visibleItemLayouts by remember(timetableScreen) { timetableScreen.visibleItemLayouts }
     val lineColor = MaterialTheme.colorScheme.surfaceVariant
     val linePxSize = with(timetableState.density) { TimetableSizes.lineStrokeSize.toPx() }
+    val layoutDirection = LocalLayoutDirection.current
 
     LazyLayout(
         modifier = modifier
+            .padding(
+                top = contentPadding.calculateTopPadding(),
+                start = contentPadding.calculateStartPadding(layoutDirection),
+                end = contentPadding.calculateEndPadding(layoutDirection),
+            )
             .focusGroup()
             .clipToBounds()
             .drawBehind {
@@ -171,7 +184,11 @@ fun Timetable(
         if (timetableScreen.width != constraint.maxWidth ||
             timetableScreen.height != constraint.maxHeight
         ) {
-            timetableScreen.updateBounds(width = constraint.maxWidth, height = constraint.maxHeight)
+            timetableScreen.updateBounds(
+                width = constraint.maxWidth,
+                height = constraint.maxHeight,
+                bottomPadding = contentPadding.calculateBottomPadding(),
+            )
             val originalContentHeight = timetableScreen.timetableLayout.timetableHeight *
                 timetableState.screenScaleState.verticalScale
             val layoutHeight = constraint.maxHeight
@@ -539,7 +556,10 @@ private class TimetableScreen(
         return (scrollState.maxY < nextPossibleY && nextPossibleY < 0f)
     }
 
-    fun updateBounds(width: Int, height: Int) {
+    fun updateBounds(width: Int, height: Int, bottomPadding: Dp) {
+        val bottomPaddingPx = with(density) {
+            bottomPadding.toPx()
+        }
         this.width = width
         this.height = height
         scrollState.updateBounds(
@@ -548,8 +568,9 @@ private class TimetableScreen(
             } else {
                 0f
             },
-            maxY = if (height < timetableLayout.timetableHeight) {
-                -(timetableLayout.timetableHeight - height).toFloat()
+            maxY = if (height < timetableLayout.timetableHeight - bottomPaddingPx) {
+                // Allow additional scrolling by bottomPadding (navigation bar height).
+                -(timetableLayout.timetableHeight - height).toFloat() - bottomPaddingPx
             } else {
                 0f
             }


### PR DESCRIPTION
## Issue
- close #459

## Overview (Required)
- I applied edge to edge into SessionsScreen.
- I fixed the issue that the navigation bar and buttons overlap in landscape
- Extends the bounds of the TimetableScreen to allow scrolling to the bottom

## Screenshot
Before | After
:--: | :--:
![Screenshot_20220914_234455](https://user-images.githubusercontent.com/13435109/190187233-fa16ea37-4abc-4bf7-a351-f52546419f21.png)|![Screenshot_20220914_233841](https://user-images.githubusercontent.com/13435109/190187367-265591ee-6733-4230-a97e-24677768e898.png)
![Screenshot_20220914_234520](https://user-images.githubusercontent.com/13435109/190187245-17df6289-595e-41d6-92a2-dfcecb2b3e2c.png)|![Screenshot_20220914_234007](https://user-images.githubusercontent.com/13435109/190187491-94d01c90-501a-43fe-892a-bbb36680d03a.png)
![Screenshot_20220914_234503](https://user-images.githubusercontent.com/13435109/190187255-0bba9036-4f20-4e88-9eda-dbff9aa36c67.png)|![Screenshot_20220914_233946](https://user-images.githubusercontent.com/13435109/190187535-788cf11a-c924-4415-a2fc-a612d9df8f34.png)
![Screenshot_20220914_234548](https://user-images.githubusercontent.com/13435109/190187260-e20fc0b1-83d7-4c41-bebc-1241dd39b707.png)|![Screenshot_20220914_233918](https://user-images.githubusercontent.com/13435109/190187580-f4d4d3ee-c4a7-4622-8229-844e11ff98db.png)
