### PR TITLE
added twitter compose rules with detekt

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -23,3 +23,31 @@ naming:
   TopLevelPropertyNaming:
     active: true
     constantPattern: '[A-Z][A-Za-z0-9]*'
+
+TwitterCompose:
+  ContentEmitterReturningValues:
+    active: false
+  ModifierComposable:
+    active: false
+  ModifierMissing:
+    active: false
+  ModifierReused:
+    active: false
+  ModifierWithoutDefault:
+    active: false
+  MultipleEmitters:
+    active: false
+  MutableParams:
+    active: false
+  ComposableNaming:
+    active: false
+  ComposableParamOrder:
+    active: false
+  PreviewPublic:
+    active: false
+  RememberMissing:
+    active: false
+  ViewModelForwarding:
+    active: false
+  ViewModelInjection:
+    active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ koin = "3.2.1"
 androidXChromeCustomTabs = "1.4.0"
 mokoResources = "0.20.1"
 detekt = '1.21.0'
+twitterComposeRulesDetekt = "0.0.8"
 
 [libraries]
 androidGradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -120,6 +121,8 @@ firebaseAuth = { module = "com.google.firebase:firebase-auth", version.ref = "fi
 coilCompose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 mokoResources = { module = "dev.icerock.moko:resources", version.ref = "mokoResources" }
 mokoResourcesCompose = { module = "dev.icerock.moko:resources-compose", version.ref = "mokoResources" }
+
+twitterComposeRulesDetekt = { module = "com.twitter.compose.rules:detekt", version.ref = "twitterComposeRulesDetekt" }
 
 # iOS
 koin = { module = "io.insert-koin:koin-core", version.ref = "koin" }

--- a/gradle/plugins/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/DetektPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/DetektPlugin.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.primitive
 import io.gitlab.arturbosch.detekt.Detekt
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.register
 
 @Suppress("unused")
@@ -11,6 +12,9 @@ class DetektPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("io.gitlab.arturbosch.detekt")
+            }
+            dependencies {
+                detektPlugins(libs.findLibrary("twitterComposeRulesDetekt"))
             }
             tasks.register<Detekt>("composeLint") {
                 config()
@@ -33,5 +37,4 @@ class DetektPlugin : Plugin<Project> {
             txt.required.set(true)
         }
     }
-
 }

--- a/gradle/plugins/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/ProjectGradleDsl.kt
+++ b/gradle/plugins/src/main/kotlin/io/github/droidkaigi/confsched2022/primitive/ProjectGradleDsl.kt
@@ -38,4 +38,10 @@ private fun DependencyHandlerScope.api(
     add("api", artifact.get())
 }
 
+fun DependencyHandlerScope.detektPlugins(
+    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+) {
+    add("detektPlugins", artifact.get())
+}
+
 val Project.libs get() = extensions.getByType<VersionCatalogsExtension>().named("libs")


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2022/issues/407

## Overview (Required)
- In this PR I disable [TwitterCompose settings in the detekt.yml](https://github.com/DroidKaigi/conference-app-2022/pull/464/files#diff-5773362839b175cf54bf2e485eba26e91827308200695eb1b592a1f491f0bd2aR27-R53), but I confirmed the rule works fine.
- To check this rules, you need to enable TwitterCompose settings in the detekt.yml and then you need to run `./gradlew composeLint`.

![Fcn45lcagAAEysv](https://user-images.githubusercontent.com/1450486/190554035-dbeef684-1661-433f-9055-70095a619fe3.png)



## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
