### PR TITLE
Remove an unnecessary padding in PermanentNavigationDrawer

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -6,9 +6,16 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.consumedWindowInsets
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -173,7 +180,7 @@ fun rememberKaigiAppScaffoldState(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun KaigiAppDrawer(
     kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState(),
@@ -185,7 +192,13 @@ fun KaigiAppDrawer(
         PermanentNavigationDrawer(
             drawerContent = { PermanentDrawerSheet { drawerSheetContent() } },
         ) {
-            content()
+            Box(
+                modifier = Modifier.consumedWindowInsets(
+                    WindowInsets.systemBars.only(WindowInsetsSides.Start)
+                )
+            ) {
+                content()
+            }
         }
     } else {
         ModalNavigationDrawer(


### PR DESCRIPTION
## Issue
- close #465

## Overview (Required)
- Remove unnecessary padding by consuming window insets.
- This padding is already consumed by the drawer.

## Links
- [Modifier.consumedWindowInsets](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#(androidx.compose.ui.Modifier).consumedWindowInsets(androidx.compose.foundation.layout.WindowInsets))

## Screenshot
Before | After
:--: | :--:
![Screenshot_20220914_235408](https://user-images.githubusercontent.com/13435109/190190828-e7903e79-d715-4033-a8ab-0c24e6f8e53e.png)|![Screenshot_20220915_080639](https://user-images.githubusercontent.com/13435109/190278314-1e03fa74-f0a5-4b07-b002-b19eb038bcf6.png)
![Screenshot_20220914_235400](https://user-images.githubusercontent.com/13435109/190190852-1895c3c6-1bb8-4b27-a93e-de6b57fc9e85.png)|![Screenshot_20220915_080619](https://user-images.githubusercontent.com/13435109/190278350-f0dcf8d0-88a4-4fbe-8012-822172b4f6b5.png)
