### PR TITLE
[Need help] :sparkles: Add Ensure that spotlessApply is executed before commit

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+formatFileList="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.kts|\.kt/ { print $NF}')"
+
+echo "spotlesscheck start..."
+for filePath in $formatFileList
+do
+  ./gradlew spotlessApply -PspotlessIdeHook="$(pwd)/$filePath"
+  echo "git add $filePath"
+  git add "$filePath"
+done;
+echo "spotlesscheck finish."

--- a/scripts/setup_pre-commit.sh
+++ b/scripts/setup_pre-commit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+
+PROJECT_DIR=$(cd $(dirname $0)/..; pwd)
+
+if [ -e "$PROJECT_DIR/.git" ]; then
+  ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+else
+  echo "  ! '$PROJECT_DIR/.git' is not found, can't link '.git/hooks/pre-commit'."
+fi


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- I have tried to run spotlessApply as appropriate at commit time because I often finally realize that I have not run spotlessApply after a failed CI check.
  - However, this is incomplete because the content of this PR will eventually make it impossible to commit without manually fixing the problem if the number of lines exceeds 100.
  - Also, it is difficult to understand why it cannot be committed, which is likely to confuse developers.
  - Therefore, I would like to make it so that if the line count check fails, the file is automatically formatted, but I have not been able to figure out how to solve this problem myself.
  - I need your help.

## Usage

- Execute the following command in the root directory of the project

```sh
./scripts/setup_pre-commit.sh
```

## Links
- https://qiita.com/a-Mana/items/f1f67b0aaaf7dc6c8e8c