### PR TITLE
Fix update-screenshot test build error

### DIFF
--- a/.github/workflows/UpdateScreenshots.yml
+++ b/.github/workflows/UpdateScreenshots.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: '11'
       - name: Run Update Screenshots
         run: ./gradlew recordPaparazziDebug


### PR DESCRIPTION
## Issue
- Related to #445

## Overview (Required)
- I fixed `screenshot-test` build error at #467.
- But I noticed about `update-screenshot` build is still failing.
  - https://github.com/DroidKaigi/conference-app-2022/actions/runs/3057751409/jobs/4933221954
- This PR is an additional fix for the above.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
