### PR TITLE
Add search word highlights

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -39,8 +39,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -178,6 +181,7 @@ private fun SearchedItemListField(
             items(sessions) {
                 SearchedItem(
                     timetableItemWithFavorite = it,
+                    searchWord = searchWord,
                     onItemClick = onItemClick,
                     onBookMarkClick = onBookMarkClick,
                 )
@@ -206,6 +210,7 @@ private fun SearchedHeader(modifier: Modifier = Modifier, day: DroidKaigi2022Day
 private fun SearchedItem(
     modifier: Modifier = Modifier,
     timetableItemWithFavorite: TimetableItemWithFavorite,
+    searchWord: String,
     onItemClick: () -> Unit,
     onBookMarkClick: () -> Unit,
 ) {
@@ -246,7 +251,10 @@ private fun SearchedItem(
                             .fillMaxSize(),
                         verticalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Text(text = timeTable.title.currentLangTitle)
+                        HighlightedText(
+                            text = timeTable.title.currentLangTitle,
+                            keyword = searchWord
+                        )
                         Text(text = "${timeTable.startsTimeString} 〜")
                         Row(
                             modifier = Modifier
@@ -293,6 +301,30 @@ private fun FullScreenLoading(modifier: Modifier = Modifier) {
     ) {
         CircularProgressIndicator()
     }
+}
+
+@Composable
+private fun HighlightedText(
+    text: String,
+    keyword: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.onSecondary,
+    backgroundColor: Color = MaterialTheme.colorScheme.secondary
+) {
+    val highlightStyle = SpanStyle(color = color, background = backgroundColor)
+    val annotatedText = remember(text, keyword) {
+        buildAnnotatedString {
+            append(text)
+            if (keyword.isNotEmpty()) {
+                var index = text.indexOf(keyword)
+                while (index >= 0) {
+                    addStyle(highlightStyle, index, index + keyword.length)
+                    index = text.indexOf(keyword, index + 1)
+                }
+            }
+        }
+    }
+    Text(text = annotatedText, modifier = modifier)
 }
 
 @Preview(showSystemUi = true)


### PR DESCRIPTION
## Issue
- close #469 

## Overview (Required)
- add highlights to text that matches the search word.
- add `HighlightedText` composable in `Search.kt`. It is a generic composable, and can be reused in other places. Though I defined it as a private composable in `Search.kt`, if you know more suitable place for it, please move it there.

## Links
- Nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48154936/190357551-a9a2f166-6cc1-40d8-867a-922ec69d1ef9.png" width="300" /> | <img src="https://user-images.githubusercontent.com/48154936/190357574-e0e63962-4fd9-4a11-ab40-471cac69529b.png" width="300" />
