### PR TITLE
Show privacy policy from the about screen with web link

### DIFF
--- a/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
+++ b/feature-about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
@@ -200,11 +200,12 @@ fun About(
                     }
                 )
 
+                val privacyPolicyUrl = "https://portal.droidkaigi.jp/about/privacy"
                 AuxiliaryInformationRow(
                     imageVector = Icons.Filled.PrivacyTip,
                     textRes = Strings.about_privacy,
                     onClick = {
-                        // TODO: Implement privacy policy
+                        onLinkClick(privacyPolicyUrl, null)
                     }
                 )
             }


### PR DESCRIPTION
## Issue
- close #188 

## Overview (Required)
- implement to show privacy policy from the about screen with the web link.

## Links
- nothing

## Recorded Video
https://user-images.githubusercontent.com/69711392/190427737-35c4c433-1c2c-45f1-83ed-7c938c7f3736.mp4
