### PR TITLE
Log the zipline network request

### DIFF
--- a/core-data/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/data/di/ApiModule.kt
+++ b/core-data/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/data/di/ApiModule.kt
@@ -74,12 +74,13 @@ class ApiModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(): OkHttpClient {
-        val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
-            level = BASIC
+        val builder = OkHttpClient.Builder()
+        if (BuildConfig.DEBUG) {
+            val httpLoggingInterceptor = HttpLoggingInterceptor()
+            httpLoggingInterceptor.level = BASIC
+            builder.addNetworkInterceptor(httpLoggingInterceptor)
         }
-        return OkHttpClient.Builder()
-            .addNetworkInterceptor(httpLoggingInterceptor)
-            .build()
+        return builder.build()
     }
 
     @Provides

--- a/core-data/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/data/di/ApiModule.kt
+++ b/core-data/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/data/di/ApiModule.kt
@@ -20,6 +20,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.logging.HttpLoggingInterceptor.Level.BASIC
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -73,7 +74,11 @@ class ApiModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(): OkHttpClient {
+        val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
+            level = BASIC
+        }
         return OkHttpClient.Builder()
+            .addNetworkInterceptor(httpLoggingInterceptor)
             .build()
     }
 


### PR DESCRIPTION
## Issue
- Part of https://github.com/DroidKaigi/conference-app-2022/issues/250

## Overview (Required)
- To make it easier to debug the zipline features, I'd like to log the zipline network requests to the logcat.

### Sample logs
```
2022-09-15 23:42:41.143 12320-12381 okhttp.OkHttpClient     io.....droidkaigi.confsched2022.dev  I  --> GET https://droidkaigi.github.io/conference-app-2022/manifest.zipline.json h2
2022-09-15 23:42:41.197 12320-12391 TrafficStats            io.....droidkaigi.confsched2022.dev  D  tagSocket(106) with statsTag=0xffffffff, statsUid=-1
2022-09-15 23:42:41.336 12320-12381 okhttp.OkHttpClient     io.....droidkaigi.confsched2022.dev  I  <-- 200 https://droidkaigi.github.io/conference-app-2022/manifest.zipline.json (193ms, 1263-byte body)
2022-09-15 23:42:41.375 12320-12381 okhttp.OkHttpClient     io.....droidkaigi.confsched2022.dev  I  --> GET https://droidkaigi.github.io/conference-app-2022/moko-resources-resources.zipline h2
2022-09-15 23:42:41.376 12320-12406 okhttp.OkHttpClient     io.....droidkaigi.confsched2022.dev  I  --> GET https://droidkaigi.github.io/conference-app-2022/kotlin-kotlin-stdlib-js-ir.zipline h2
2022-09-15 23:42:41.376 12320-12405 okhttp.OkHttpClient     io.....droidkaigi.confsched2022.dev  I  --> GET https://droidkaigi.github.io/conference-app-2022/moko-parcelize-parcelize-js-ir.zipline h2
2022-09-15 23:42:41.612 12320-12381 okhttp.OkHttpClient     io.....droidkaigi.confsched2022.dev  I  <-- 200 https://droidkaigi.github.io/conference-app-2022/moko-resources-resources.zipline (237ms, 360-byte body)
2022-09-15 23:42:41.613 12320-12406 okhttp.OkHttpClient     io.....droidkaigi.confsched2022.dev  I  <-- 200 https://droidkaigi.github.io/conference-app-2022/kotlin-kotlin-stdlib-js-ir.zipline (236ms, 213265-byte body)
```