### PR TITLE
Removed useless content padding in SessionScreen

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -142,10 +142,7 @@ fun Sessions(
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .padding(top = 4.dp)
-        ) {
+        Column {
             when (scheduleState) {
                 is Error -> {
                     scheduleState.value?.printStackTrace()


### PR DESCRIPTION
## Issue
- close #496 Delete unneeded space between day and list

## Overview (Required)
- The cause of this issue is probably adding unnecessary top padding to the root column in the KaigiScaffold.
- Removing this padding solved the issue, but I didn't understand the intent of this padding, so I would like a review and approve about deleting this Padding

## Screenshot
| Before | After |
:--: | :--:
<img src="https://user-images.githubusercontent.com/56629437/190540642-aa51aab3-1980-47d5-8551-998ae3dab2b2.png" width="300" /> | <img src="https://user-images.githubusercontent.com/56629437/190540751-97e1073b-8bb0-4872-a4f2-5981967cf9e8.png" width="300" />
