### PR TITLE
:wrench: Fix Icons, etc. are now displayed even for users who cannot obtain icons from sessionize.

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -485,38 +485,37 @@ fun SessionDetailSpeakers(
         Spacer(modifier = Modifier.padding(16.dp))
 
         speakers.forEach { speaker ->
-            if (speaker.iconUrl.isNotEmpty()) {
-                Row(
+            Row(
+                modifier = Modifier
+                    .clearAndSetSemantics {
+                        contentDescription = speaker.name
+                    },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                AsyncImage(
+                    model = speaker.iconUrl,
                     modifier = Modifier
-                        .clearAndSetSemantics {
-                            contentDescription = speaker.name
-                        },
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    AsyncImage(
-                        model = speaker.iconUrl,
-                        modifier = Modifier
-                            .size(60.dp)
-                            .clip(CircleShape),
-                        placeholder = painterResource(R.drawable.ic_baseline_person_24),
-                        contentScale = ContentScale.Fit,
-                        alignment = Alignment.Center,
-                        contentDescription = "Speaker Icon",
-                    )
-                    Spacer(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                    )
-                    // TODO Transition to Speaker detail
-                    Text(
-                        modifier = Modifier,
-                        text = speaker.name,
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                }
+                        .size(60.dp)
+                        .clip(CircleShape),
+                    placeholder = painterResource(R.drawable.ic_baseline_person_24),
+                    error = painterResource(R.drawable.ic_baseline_person_24),
+                    contentScale = ContentScale.Fit,
+                    alignment = Alignment.Center,
+                    contentDescription = "Speaker Icon",
+                )
                 Spacer(
-                    modifier = Modifier.padding(vertical = 12.dp)
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+                // TODO Transition to Speaker detail
+                Text(
+                    modifier = Modifier,
+                    text = speaker.name,
+                    style = MaterialTheme.typography.bodyLarge,
                 )
             }
+            Spacer(
+                modifier = Modifier.padding(vertical = 12.dp)
+            )
         }
 
         Spacer(


### PR DESCRIPTION
## Issue
- close #488 

## Overview (Required)
- As the title says.
  - It seems that certain people are not able to get icons from sessionize.
  - The icon is not displayed on the web either.

## Links
- https://droidkaigi.jp/2022/timetable/364756

<img src="https://user-images.githubusercontent.com/13657682/190570397-f4ba83e7-6323-48b2-b13b-8798be7e066d.png" width="300" />

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13657682/190570116-219b79da-fe5f-4520-aae5-e196923fe533.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13657682/190570106-7ea028d4-bd57-4c5d-9bcb-093a4fd491d1.png" width="300" />