### PR TITLE
Suppress warnings in build.gradle.kts (DroidKaigi2022)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    // https://youtrack.jetbrains.com/issue/KTIJ-19369/False-positive-cant-be-called-in-this-context-by-implicit-receiver-with-plugins-in-Gradle-version-catalogs-as-a-TOML-file#focus=Comments-27-6204464.0-0
     @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.androidGradlePlugin) apply false
     @Suppress("DSL_SCOPE_VIOLATION")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
+    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.androidGradlePlugin) apply false
+    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.androidGradleLibraryPlugin) apply false
+    @Suppress("DSL_SCOPE_VIOLATION")
     alias(libs.plugins.kotlinPlugin) apply false
     id("droidkaigi.primitive.dependencygraph")
 }


### PR DESCRIPTION
## Issue
- close #438

## Overview (Required)
- Suppress the warning `val Project.libs: LibrariesForLibs' can't be called in this context by implicit receiver. Use the explicit one if necessary` in build.gradle.kts (DroidKaigi2022).
  - First, I tried to add `@Suppress("DSL_SCOPE_VIOLATION")` above `plugins { … }` as follows …
    <img src="https://user-images.githubusercontent.com/1838962/190574197-154e24cb-e437-4c67-b7e0-335d07a77a2a.png" width="320" />
… but got the build error `e: build.gradle.kts:1:33: Expecting an expression`.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1838962/190572859-fd3f1b4d-9013-4034-9aa7-40081ffdf519.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1838962/190573802-6f1b3d35-9ed0-4568-9f72-860302a0cb13.png" width="300" />