### PR TITLE
[iOS] Shrink timetable day selection

### DIFF
--- a/app-ios/Sources/AppFeature/AppView.swift
+++ b/app-ios/Sources/AppFeature/AppView.swift
@@ -205,6 +205,20 @@ public struct AppView: View {
 
         // workaround for tabbar colors. From iOS16, toolbarBackground may be useful
         UITabBar.appearance().barTintColor = AssetColors.surface.color
+
+        // workaround for preventing translucent tabbar. From iOS15
+        let tabBarAppearance: UITabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.backgroundColor = AssetColors.surface.color
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+
+        // workaround for preventing translucent navigation bar. From iOS15
+        let navigationBarAppearance = UINavigationBarAppearance()
+        navigationBarAppearance.backgroundColor = AssetColors.surface.color
+        navigationBarAppearance.shadowColor = .clear
+        UINavigationBar.appearance().standardAppearance = navigationBarAppearance
+        UINavigationBar.appearance().compactAppearance = navigationBarAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navigationBarAppearance
     }
 
     public var body: some View {

--- a/app-ios/Sources/TimetableFeature/Component/ScrollDetector.swift
+++ b/app-ios/Sources/TimetableFeature/Component/ScrollDetector.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct ScrollDetector: View {
+
+    private struct ScrollPreferenceKey: PreferenceKey {
+        static var defaultValue: CGRect = .zero
+        static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+            value = nextValue()
+        }
+    }
+
+    let coordinateSpace: CoordinateSpace
+    var onDetect: (CGPoint) -> Void
+
+    init(coordinateSpace: CoordinateSpace, onDetect: @escaping (CGPoint) -> Void = { _ in }) {
+        self.coordinateSpace = coordinateSpace
+        self.onDetect = onDetect
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            VStack {
+            }
+            .preference(key: ScrollPreferenceKey.self, value: proxy.frame(in: coordinateSpace))
+        }
+        .onPreferenceChange(ScrollPreferenceKey.self) {
+            onDetect($0.origin)
+        }
+    }
+
+    func onDetect(perform action: @escaping (CGPoint) -> Void) -> some View {
+        var view = self
+        view.onDetect = action
+        return view
+    }
+}
+
+protocol ScrollDetectable {
+    var scrollThreshold: CGFloat { get set }
+    var onScroll: (CGPoint) -> Void { get set }
+}
+extension ScrollDetectable where Self: View {
+
+    func scrollThreshold(_ value: CGFloat) -> Self {
+        var view = self
+        view.scrollThreshold = value
+        return view
+    }
+
+    func onScroll(perform action: @escaping (CGPoint) -> Void) -> Self {
+        var view = self
+        view.onScroll = action
+        return view
+    }
+}

--- a/app-ios/Sources/TimetableFeature/Content/ListView.swift
+++ b/app-ios/Sources/TimetableFeature/Content/ListView.swift
@@ -4,7 +4,11 @@ import Theme
 import Model
 import ComposableArchitecture
 
-struct TimetableListView: View {
+struct TimetableListView: View, ScrollDetectable {
+
+    var scrollThreshold: CGFloat = 0
+    var onScroll: (CGPoint) -> Void = { _ in }
+
     struct ViewState: Equatable {
         var timeGroupTimetableItems: [TimetableTimeGroupItems]
 
@@ -43,6 +47,10 @@ struct TimetableListView: View {
     var body: some View {
         WithViewStore(store.scope(state: ViewState.init)) { viewStore in
             ScrollView(.vertical) {
+
+                Spacer()
+                    .frame(height: scrollThreshold)
+
                 LazyVStack(spacing: 32) {
                     ForEach(viewStore.timeGroupTimetableItems) { timetableTimeGroupItems in
                         HStack(alignment: .top, spacing: 28) {
@@ -74,7 +82,14 @@ struct TimetableListView: View {
                     }
                 }
                 .padding(.vertical, 24)
+                .background(
+                    ScrollDetector(coordinateSpace: .named("TimetableListView"))
+                        .onDetect { position in
+                            onScroll(position)
+                        }
+                )
             }
+            .coordinateSpace(name: "TimetableListView")
         }
     }
 

--- a/app-ios/Sources/TimetableFeature/Content/ListView.swift
+++ b/app-ios/Sources/TimetableFeature/Content/ListView.swift
@@ -1,8 +1,8 @@
 import Assets
+import ComposableArchitecture
+import Model
 import SwiftUI
 import Theme
-import Model
-import ComposableArchitecture
 
 struct TimetableListView: View, ScrollDetectable {
 

--- a/app-ios/Sources/TimetableFeature/Content/SheetView.swift
+++ b/app-ios/Sources/TimetableFeature/Content/SheetView.swift
@@ -5,6 +5,7 @@ import Theme
 
 struct TimetableSheetView: View, ScrollDetectable {
 
+    var scrollThreshold: CGFloat = 0
     var onScroll: (CGPoint) -> Void = { _ in }
 
     struct ViewState: Equatable {
@@ -76,9 +77,8 @@ struct TimetableSheetView: View, ScrollDetectable {
         WithViewStore(store.scope(state: ViewState.init)) { viewStore in
             ScrollView(.vertical) {
 
-                ScrollDetector(coordinateSpace: .named("TimetableSheetView"))
-                    .onDetect(onScroll)
-                    .frame(height: 96)
+                Spacer()
+                    .frame(height: scrollThreshold)
 
                 HStack(alignment: .top, spacing: 0) {
                     Spacer()
@@ -128,6 +128,12 @@ struct TimetableSheetView: View, ScrollDetectable {
                         }
                     }
                 }
+                .background(
+                    ScrollDetector(coordinateSpace: .named("TimetableSheetView"))
+                        .onDetect { position in
+                            onScroll(position)
+                        }
+                )
             }
             .coordinateSpace(name: "TimetableSheetView")
         }

--- a/app-ios/Sources/TimetableFeature/Content/SheetView.swift
+++ b/app-ios/Sources/TimetableFeature/Content/SheetView.swift
@@ -3,7 +3,10 @@ import Model
 import SwiftUI
 import Theme
 
-struct TimetableSheetView: View {
+struct TimetableSheetView: View, ScrollDetectable {
+
+    var onScroll: (CGPoint) -> Void = { _ in }
+
     struct ViewState: Equatable {
         var roomTimetableItems: [TimetableRoomItems]
         var hours: [Int]
@@ -72,6 +75,10 @@ struct TimetableSheetView: View {
     var body: some View {
         WithViewStore(store.scope(state: ViewState.init)) { viewStore in
             ScrollView(.vertical) {
+
+                ScrollDetector(coordinateSpace: .named("TimetableSheetView"))
+                    .onDetect(onScroll)
+
                 HStack(alignment: .top, spacing: 0) {
                     Spacer()
                         .frame(width: 16)
@@ -121,6 +128,7 @@ struct TimetableSheetView: View {
                     }
                 }
             }
+            .coordinateSpace(name: "TimetableSheetView")
         }
     }
 }

--- a/app-ios/Sources/TimetableFeature/Content/SheetView.swift
+++ b/app-ios/Sources/TimetableFeature/Content/SheetView.swift
@@ -78,6 +78,7 @@ struct TimetableSheetView: View, ScrollDetectable {
 
                 ScrollDetector(coordinateSpace: .named("TimetableSheetView"))
                     .onDetect(onScroll)
+                    .frame(height: 96)
 
                 HStack(alignment: .top, spacing: 0) {
                     Spacer()

--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -168,60 +168,6 @@ public struct TimetableView: View {
     }
 }
 
-struct ScrollDetector: View {
-
-    private struct ScrollPreferenceKey: PreferenceKey {
-        static var defaultValue: CGRect = .zero
-        static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
-            value = nextValue()
-        }
-    }
-
-    let coordinateSpace: CoordinateSpace
-    var onDetect: (CGPoint) -> Void
-
-    init(coordinateSpace: CoordinateSpace, onDetect: @escaping (CGPoint) -> Void = { _ in }) {
-        self.coordinateSpace = coordinateSpace
-        self.onDetect = onDetect
-    }
-
-    var body: some View {
-        GeometryReader { proxy in
-            VStack {
-            }
-            .preference(key: ScrollPreferenceKey.self, value: proxy.frame(in: coordinateSpace))
-        }
-        .onPreferenceChange(ScrollPreferenceKey.self) {
-            onDetect($0.origin)
-        }
-    }
-
-    func onDetect(perform action: @escaping (CGPoint) -> Void) -> some View {
-        var view = self
-        view.onDetect = action
-        return view
-    }
-}
-
-protocol ScrollDetectable {
-    var scrollThreshold: CGFloat { get set }
-    var onScroll: (CGPoint) -> Void { get set }
-}
-extension ScrollDetectable where Self: View {
-
-    func scrollThreshold(_ value: CGFloat) -> Self {
-        var view = self
-        view.scrollThreshold = value
-        return view
-    }
-
-    func onScroll(perform action: @escaping (CGPoint) -> Void) -> Self {
-        var view = self
-        view.onScroll = action
-        return view
-    }
-}
-
 #if DEBUG
 struct TimetableView_Previews: PreviewProvider {
     static var previews: some View {

--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -107,8 +107,6 @@ public struct TimetableView: View {
                                 VStack(spacing: 0) {
                                     Text(day.name)
                                         .font(Font.system(size: 12, weight: .semibold))
-                                        .baselineOffset(0)
-                                        .baselineOffset(0)
                                     if viewStore.showDate {
                                         Text("\(startDay)")
                                             .font(Font.system(size: 24, weight: .semibold))

--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -76,6 +76,9 @@ public struct TimetableView: View {
         self.store = store
     }
 
+    @State var showTabDay: Bool = true
+    @State var scrollY: CGFloat = 0.0
+
     public var body: some View {
         WithViewStore(store) { viewStore in
             NavigationView {
@@ -91,9 +94,12 @@ public struct TimetableView: View {
                                 VStack(spacing: 0) {
                                     Text(day.name)
                                         .font(Font.system(size: 12, weight: .semibold))
-                                    Text("\(startDay)")
-                                        .font(Font.system(size: 24, weight: .semibold))
-                                        .frame(height: 32)
+                                    if showTabDay {
+                                        Text("\(startDay)")
+                                            .font(Font.system(size: 24, weight: .semibold))
+                                            .frame(height: 32)
+                                            .transition(.move(edge: .top).combined(with: .opacity))
+                                    }
                                 }
                                 .padding(4)
                                 .frame(maxWidth: .infinity)
@@ -112,8 +118,8 @@ public struct TimetableView: View {
                     .background(AssetColors.surface.swiftUIColor)
 
                     TimetableSheetView(store: store)
-                        .onScroll { position in
-                            print("onScroll: \(position)")
+                        .onScroll {
+                            onScroll(position: $0)
                         }
                 }
                 .task {
@@ -147,6 +153,13 @@ public struct TimetableView: View {
                 .navigationBarTitleDisplayMode(.inline)
             }
             .navigationViewStyle(.stack)
+        }
+    }
+
+    func onScroll(position: CGPoint) {
+        scrollY = position.y * (-1)
+        withAnimation {
+            showTabDay = scrollY <= 0
         }
     }
 }

--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -82,7 +82,13 @@ public struct TimetableView: View {
     public var body: some View {
         WithViewStore(store) { viewStore in
             NavigationView {
-                VStack(spacing: 0) {
+                ZStack(alignment: .top) {
+
+                    TimetableSheetView(store: store)
+                        .onScroll {
+                            onScroll(position: $0)
+                        }
+
                     HStack(spacing: 8) {
                         ForEach(
                             [DroidKaigi2022Day].fromKotlinArray(DroidKaigi2022Day.values())
@@ -116,11 +122,6 @@ public struct TimetableView: View {
                     .padding(.vertical, 16)
                     .foregroundColor(AssetColors.onSurface.swiftUIColor)
                     .background(AssetColors.surface.swiftUIColor)
-
-                    TimetableSheetView(store: store)
-                        .onScroll {
-                            onScroll(position: $0)
-                        }
                 }
                 .task {
                     await viewStore.send(.refresh).finish()

--- a/app-ios/Sources/TimetableFeature/TimetableView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableView.swift
@@ -8,16 +8,16 @@ import Theme
 public struct TimetableState: Equatable {
     public var dayToTimetable: [DroidKaigi2022Day: Timetable]
     public var selectedDay: DroidKaigi2022Day
-    public var showTabDay: Bool
+    public var showDate: Bool
 
     public init(
         dayToTimetable: [DroidKaigi2022Day: Timetable] = [:],
         selectedDay: DroidKaigi2022Day = .day1,
-        showTabDay: Bool = true
+        showDate: Bool = true
     ) {
         self.dayToTimetable = dayToTimetable
         self.selectedDay = selectedDay
-        self.showTabDay = showTabDay
+        self.showDate = showDate
     }
 }
 
@@ -71,7 +71,7 @@ public let timetableReducer = Reducer<TimetableState, TimetableAction, Timetable
         .receive(on: DispatchQueue.main.eraseToAnyScheduler())
         .eraseToEffect()
     case let .scroll(position):
-        state.showTabDay = position.y >= TimetableView.scrollThreshold
+        state.showDate = position.y >= TimetableView.scrollThreshold
         return .none
     }
 }
@@ -109,7 +109,7 @@ public struct TimetableView: View {
                                         .font(Font.system(size: 12, weight: .semibold))
                                         .baselineOffset(0)
                                         .baselineOffset(0)
-                                    if viewStore.showTabDay {
+                                    if viewStore.showDate {
                                         Text("\(startDay)")
                                             .font(Font.system(size: 24, weight: .semibold))
                                             .frame(height: 32)
@@ -124,7 +124,7 @@ public struct TimetableView: View {
                                     : AssetColors.surface.swiftUIColor
                                 )
                                 .clipShape(Capsule())
-                                .animation(.linear(duration: 0.2), value: viewStore.showTabDay)
+                                .animation(.linear(duration: 0.2), value: viewStore.showDate)
                             }
                         }
                     }


### PR DESCRIPTION
## Issue
- close #433

## Overview (Required)
 - To detect scrolling, using GeometryReader.
 - Similar behavior to Android edition (expand upper tab when scrolling reached top edge).

## Links
- https://github.com/DroidKaigi/conference-app-2022/pull/357

## Screenshot
Before | After
:--: | :--:
<video src="https://user-images.githubusercontent.com/26338889/190649024-68749eb5-2b1b-49cf-bbd7-3880e5807315.mp4" width="300" />|<video src="https://user-images.githubusercontent.com/26338889/190649219-92fdeae6-af5f-4525-a0b4-9b9eaeeda630.mp4" width="300" />

