### PR TITLE
[iOS] Add vertical spacing between the timetable items

### DIFF
--- a/app-ios/Sources/TimetableFeature/Content/SheetView.swift
+++ b/app-ios/Sources/TimetableFeature/Content/SheetView.swift
@@ -61,6 +61,7 @@ struct TimetableSheetView: View {
     }
 
     private static let minuteHeight: CGFloat = 4
+    private static let verticalItemSpacing: CGFloat = 3
     private static let timetableStartTime: DateComponents = .init(hour: 10, minute: 0)
     private let dateComponentsFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
@@ -106,7 +107,8 @@ struct TimetableSheetView: View {
                                     ForEach(timetableItems) { item in
                                         if case let .general(item, minutes) = item {
                                             TimetableItemView(item: item)
-                                                .frame(height: CGFloat(minutes) * TimetableSheetView.minuteHeight)
+                                                .frame(height: CGFloat(minutes) * TimetableSheetView.minuteHeight - TimetableSheetView.verticalItemSpacing)
+                                                .padding(.bottom, TimetableSheetView.verticalItemSpacing)
                                         } else if case let .spacing(minutes) = item {
                                             Spacer()
                                                 .frame(maxHeight: CGFloat(minutes) * TimetableSheetView.minuteHeight)


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- As the title says

## Links
- [App Design](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5673994/190702958-48d47942-c65c-479b-baaf-86310630bbca.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5673994/190702999-4c0fbf17-e592-430d-b6b5-cadb861f9d9e.png" width="300" />