### PR TITLE
Add a yml file for workflow_run trigger

### DIFF
--- a/.github/workflows/CommentPR.yml
+++ b/.github/workflows/CommentPR.yml
@@ -1,0 +1,19 @@
+name: Comment on the pull request
+on:
+  workflow_run:
+    workflows:
+      - ScreenShotTest
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifact
+        run: echo "download artifact later"
+      - name: Comment PR
+        run: echo "comment pr later"

--- a/.github/workflows/ScreenShotTest.yml
+++ b/.github/workflows/ScreenShotTest.yml
@@ -1,3 +1,4 @@
+name: ScreenShotTest
 on:
   pull_request:
 


### PR DESCRIPTION
## Issue
- #497

## Overview (Required)
- I want to merge this PR in its current state. 
Because  I try to separate ScreenShotTest workflow and  I use  `workflow_run` trigger but I can’t check for the bellow reason.
After merge the PR, I’m going to do [the remaining work](https://github.com/DroidKaigi/conference-app-2022/pull/541).

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
