### PR TITLE
Fix day tabs's font

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
@@ -21,12 +21,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched2022.designsystem.theme.montserratFonts
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day
 
@@ -64,14 +60,10 @@ internal fun SessionDayTab(
             ) {
                 Text(
                     text = "${5 + index}",
-                    style = TextStyle(
+                    style = MaterialTheme.typography.headlineSmall.copy(
                         color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight.W500,
-                        fontStyle = FontStyle.Normal,
                         fontFamily = montserratFonts,
-                        textAlign = TextAlign.Center,
-                        lineHeight = 32.sp
+                        textAlign = TextAlign.Center
                     ),
                     modifier = Modifier.fillMaxWidth()
                 )

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDayTab.kt
@@ -22,10 +22,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.droidkaigi.confsched2022.designsystem.theme.montserratFonts
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day
 
 @Composable
@@ -49,11 +51,9 @@ internal fun SessionDayTab(
         ) {
             Text(
                 text = day.name,
-                style = TextStyle(
+                style = MaterialTheme.typography.labelMedium.copy(
                     textAlign = TextAlign.Center,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight(500)
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
                 ),
                 modifier = Modifier.fillMaxWidth()
             )
@@ -65,10 +65,13 @@ internal fun SessionDayTab(
                 Text(
                     text = "${5 + index}",
                     style = TextStyle(
-                        textAlign = TextAlign.Center,
                         color = MaterialTheme.colorScheme.onSecondaryContainer,
                         fontSize = 24.sp,
-                        fontWeight = FontWeight(500)
+                        fontWeight = FontWeight.W500,
+                        fontStyle = FontStyle.Normal,
+                        fontFamily = montserratFonts,
+                        textAlign = TextAlign.Center,
+                        lineHeight = 32.sp
                     ),
                     modifier = Modifier.fillMaxWidth()
                 )


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2022/issues/492

## Overview (Required)
- Fix day tab's font

### Day's Font Design
- fontFamily: Montserrat
- fontSize: 24sp
- fontWeight: 500
- lineHeight: 32sp
- fontStyle: Normal(= W3)

## Links
- Design: https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1

## Screenshot
Before | After
:--: | :--:
<img src='https://user-images.githubusercontent.com/23094546/190847169-229d54cc-6761-4c3d-b5ad-2028fde9fa2c.png' width=300 /> | <img src='https://user-images.githubusercontent.com/23094546/190847185-8c24b339-27e1-406e-b5fb-8245174c9cec.png' width=300 />
