### PR TITLE
Apply font to time and room on session list

### DIFF
--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
@@ -32,7 +32,8 @@ fun HoursItem(
         text = hour,
         color = Color.White,
         modifier = modifier,
-        textAlign = TextAlign.Center
+        textAlign = TextAlign.Center,
+        style = MaterialTheme.typography.titleMedium
     )
 }
 

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -323,13 +323,19 @@ fun SessionsList(
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
                             timeHeader?.let {
-                                Text(text = it.startAt)
+                                Text(
+                                    text = it.startAt,
+                                    style = MaterialTheme.typography.titleMedium
+                                )
                                 Box(
                                     modifier = Modifier
                                         .size(1.dp, 2.dp)
                                         .background(MaterialTheme.colorScheme.onBackground)
                                 ) { }
-                                Text(text = it.endAt)
+                                Text(
+                                    text = it.endAt,
+                                    style = MaterialTheme.typography.titleMedium
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Issue
- close #486 

## Overview (Required)
- applied specified font to the places where time shows on  the session list.

## Links
- 

## Screenshot
Before1 | After1
:--: | :--:
<img src="https://user-images.githubusercontent.com/69711392/190856543-224fd86d-a8c0-41ff-9572-0f9c363f8748.png" width="300" /> | <img src="https://user-images.githubusercontent.com/69711392/190856427-a688004e-fd5a-472f-b65e-a515a205ed37.png" width="300" />

Before2 | After2
:--: | :--:
<img src="https://user-images.githubusercontent.com/69711392/190856295-df50a5ff-0abc-47de-8d08-56edc7378811.png" width="300" /> | <img src="https://user-images.githubusercontent.com/69711392/190856444-6b7ee305-c987-432c-b8b7-71585dcdca1a.png" width="300" />

