### PR TITLE
Activate the ModifierMissing rule

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -30,7 +30,7 @@ TwitterCompose:
   ModifierComposable:
     active: true
   ModifierMissing:
-    active: false
+    active: true
   ModifierReused:
     active: false
   ModifierWithoutDefault:

--- a/feature-announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcement.kt
+++ b/feature-announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcement.kt
@@ -19,15 +19,20 @@ fun AnnouncementScreenRoot(
     showNavigationIcon: Boolean = true,
     onNavigationIconClick: () -> Unit,
 ) {
-    Announcement(showNavigationIcon, onNavigationIconClick)
+    Announcement(
+        showNavigationIcon = showNavigationIcon,
+        onNavigationIconClick = onNavigationIconClick
+    )
 }
 
 @Composable
 fun Announcement(
+    modifier: Modifier = Modifier,
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
 ) {
     KaigiScaffold(
+        modifier = modifier,
         topBar = {
             KaigiTopAppBar(
                 showNavigationIcon = showNavigationIcon,

--- a/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -34,17 +34,24 @@ fun ContributorsScreenRoot(
     onLinkClick: (url: String, packageName: String?) -> Unit = { _, _ -> },
 ) {
     val uiModel by viewModel.uiModel
-    Contributors(uiModel, showNavigationIcon, onNavigationIconClick, onLinkClick)
+    Contributors(
+        uiModel = uiModel,
+        showNavigationIcon = showNavigationIcon,
+        onNavigationIconClick = onNavigationIconClick,
+        onLinkClick = onLinkClick
+    )
 }
 
 @Composable
 fun Contributors(
+    modifier: Modifier = Modifier,
     uiModel: ContributorsUiModel,
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
     onLinkClick: (url: String, packageName: String?) -> Unit
 ) {
     KaigiScaffold(
+        modifier = modifier,
         topBar = {
             KaigiTopAppBar(
                 showNavigationIcon = showNavigationIcon,

--- a/feature-map/src/main/java/io/github/droidkaigi/confsched2022/feature/map/Map.kt
+++ b/feature-map/src/main/java/io/github/droidkaigi/confsched2022/feature/map/Map.kt
@@ -15,9 +15,11 @@ fun MapScreenRoot() {
 }
 
 @Composable
-fun Map() {
+fun Map(
+    modifier: Modifier = Modifier,
+) {
     Box(
-        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        modifier = modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -218,6 +218,7 @@ fun SessionDetailScreen(
 
 @Composable
 fun SessionDetailBottomAppBar(
+    modifier: Modifier = Modifier,
     item: TimetableItem,
     isFavorite: Boolean,
     onFavoriteClick: (Boolean) -> Unit,
@@ -225,7 +226,7 @@ fun SessionDetailBottomAppBar(
     onNavigateFloorMapClick: () -> Unit,
     onRegisterCalendarClick: (TimetableItem) -> Unit,
 ) {
-    BottomAppBar {
+    BottomAppBar(modifier = modifier) {
         Row(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
@@ -277,6 +278,7 @@ fun SessionDetailBottomAppBar(
 
 @Composable
 fun SessionTagsLine(
+    modifier: Modifier = Modifier,
     item: TimetableItem
 ) {
     val sessionMinutes =
@@ -286,6 +288,7 @@ fun SessionTagsLine(
     val secondLang = lang.secondLang()
 
     FlowRow(
+        modifier = modifier,
         mainAxisSize = Expand,
         mainAxisSpacing = 8.dp,
         crossAxisSpacing = 8.dp

--- a/feature-setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
+++ b/feature-setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
@@ -31,15 +31,20 @@ fun SettingScreenRoot(
     showNavigationIcon: Boolean = true,
     onNavigationIconClick: () -> Unit = {}
 ) {
-    Setting(showNavigationIcon, onNavigationIconClick)
+    Setting(
+        showNavigationIcon = showNavigationIcon,
+        onNavigationIconClick = onNavigationIconClick
+    )
 }
 
 @Composable
 fun Setting(
+    modifier: Modifier = Modifier,
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit
 ) {
     KaigiScaffold(
+        modifier = modifier,
         topBar = {
             KaigiTopAppBar(
                 showNavigationIcon = showNavigationIcon,
@@ -76,12 +81,13 @@ enum class SettingItem(val titleStringRes: StringResource, val icon: ImageVector
 
 @Composable
 fun SettingItem(
+    modifier: Modifier = Modifier,
     icon: ImageVector,
     title: String
 ) {
     val checkedState = remember { mutableStateOf(true) }
     Row(
-        modifier = Modifier
+        modifier = modifier
             .padding(vertical = 8.dp)
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,


### PR DESCRIPTION
This pull request activates the `ModifierMissing` Detekt rule and fixes errors by **simply adding a `modifier` parameter** to composable functions.

Note that all errors can also be fixed by [**changing their visibility scope to non-public**](https://github.com/twitter/compose-rules/blob/e71bc59fcee526ecdf6ffc97095532111012836e/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierMissingCheckTest.kt#L79). However, I can see many other composable functions that can be marked `private` in the project and do not want to break code consistency as possible for fixing this lint error. In my opinion, changing the visibility scope should be another refactoring issue.

## Issue
- close #512

## Overview (Required)
- Activates the `ModifierMissing` rule of [twitter/compose-rules](https://github.com/twitter/compose-rules)

## Links
- [ComposeModifierMissingCheckTest.kt  ---  test code that describes how ModifierMissing should behave](https://github.com/twitter/compose-rules/blob/main/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierMissingCheckTest.kt)
- (ref.) [Chris Banes - Always provide a Modifier parameter](https://chris.banes.dev/always-provide-a-modifier/)

## Fixed lint errors

```
ModifierMissing - [This @Composable function emits content but doesn't have a modifier parameter. S(...)] at ***/conference-app-2022/feature-announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcement.kt:26:5
ModifierMissing - [This @Composable function emits content but doesn't have a modifier parameter. S(...)] at ***/conference-app-2022/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt:220:5
ModifierMissing - [This @Composable function emits content but doesn't have a modifier parameter. S(...)] at ***/conference-app-2022/feature-sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt:279:5
ModifierMissing - [This @Composable function emits content but doesn't have a modifier parameter. S(...)] at ***/conference-app-2022/feature-setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt:38:5
ModifierMissing - [This @Composable function emits content but doesn't have a modifier parameter. S(...)] at ***/conference-app-2022/feature-setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt:78:5
ModifierMissing - [This @Composable function emits content but doesn't have a modifier parameter. S(...)] at ***/conference-app-2022/feature-map/src/main/java/io/github/droidkaigi/confsched2022/feature/map/Map.kt:18:5
ModifierMissing - [This @Composable function emits content but doesn't have a modifier parameter. S(...)] at ***/conference-app-2022/feature-contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt:41:5
```