### PR TITLE
[iOS] Add horizontal padding to the app version label

### DIFF
--- a/app-ios/Sources/AboutFeature/AboutView.swift
+++ b/app-ios/Sources/AboutFeature/AboutView.swift
@@ -119,6 +119,7 @@ public struct AboutView: View {
                         .padding(16)
                         .frame(minHeight: 56)
                     }
+                    .padding(.horizontal, 29)
 
                     Spacer()
                         .frame(height: 32)


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR adds horizontal padding to the app version label in About view

## Links
- [App Design](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=448%3A2009)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5673994/190867261-9c49ff5f-3651-46dd-8c0f-c969e5334421.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5673994/190867264-7ad033b9-b082-41d1-bfa2-c49f33732840.png" width="300" />