### PR TITLE
Activate ModifierWithoutDefault twitter/compose-rules and fix

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -34,7 +34,7 @@ TwitterCompose:
   ModifierReused:
     active: false
   ModifierWithoutDefault:
-    active: false
+    active: true
   MultipleEmitters:
     active: false
   MutableParams:

--- a/feature-sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
+++ b/feature-sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
@@ -27,7 +27,7 @@ fun SponsorsScreenRoot(
 
 @Composable
 fun Sponsors(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit
 ) {


### PR DESCRIPTION
## Issue
- close #514

## Overview (Required)
- activate ModifierWithoutDefault of twitter/compose-rules
- The rules are as follows
  - Modifiers should have default parameters

## Links
- https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters

## Screenshot
Before1 | Before2 | After
:--: | :--: | :--:
<img src="https://user-images.githubusercontent.com/31497808/190877372-f857d0c6-e59c-4a7e-a7fd-82f80b637a38.png" width="300" /> | <img src="https://user-images.githubusercontent.com/31497808/190877366-cf0816cd-1fbe-4b1a-85f0-f99dc582cff2.png" width="300" /> | <img src="https://user-images.githubusercontent.com/31497808/190877403-94855625-a44f-487c-9a98-ff1c516a70ca.png" width="300" />
