### PR TITLE
Active MultipleEmitters twitter/compose-rules

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -36,7 +36,7 @@ TwitterCompose:
   ModifierWithoutDefault:
     active: true
   MultipleEmitters:
-    active: false
+    active: true
   MutableParams:
     active: false
   ComposableNaming:


### PR DESCRIPTION
## Issue
- close #515 

## Overview (Required)
- active `MultipleEmitters` rule of compose-rules
  - No lint error.

## Links
- [Ruleset](https://twitter.github.io/compose-rules/rules/)