### PR TITLE
Activate ComposableNaming twitter/compose-rules

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -40,7 +40,7 @@ TwitterCompose:
   MutableParams:
     active: false
   ComposableNaming:
-    active: false
+    active: true
   ComposableParamOrder:
     active: false
   PreviewPublic:


### PR DESCRIPTION
## Issue
- close #517

## Overview (Required)
- Activate ComposableNaming twitter/compose-rules.
    - `./gradlew composeLint` runs successfully.

## Links
- https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly