### PR TITLE
Activate MutableParams twitter/compose-rules

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -38,7 +38,7 @@ TwitterCompose:
   MultipleEmitters:
     active: false
   MutableParams:
-    active: false
+    active: true
   ComposableNaming:
     active: false
   ComposableParamOrder:


### PR DESCRIPTION
## Issue
- close #516

## Overview (Required)
- Activate MutableParams twitter/compose-rules.
    - `./gradlew composeLint` runs successfully.

## Links
- https://twitter.github.io/compose-rules/rules/#do-not-use-inherently-mutable-types-as-parameters
