### PR TITLE
hide the software keyboard when the drawer menu starts expanding.

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -47,9 +47,11 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -182,7 +184,11 @@ fun rememberKaigiAppScaffoldState(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalLayoutApi::class,
+    ExperimentalComposeUiApi::class
+)
 @Composable
 fun KaigiAppDrawer(
     kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState(),
@@ -203,8 +209,13 @@ fun KaigiAppDrawer(
             }
         }
     } else {
+        val keyboardController = LocalSoftwareKeyboardController.current
+        val drawerState = kaigiAppScaffoldState.drawerState
+        if (drawerState.isAnimationRunning && drawerState.isClosed) {
+            keyboardController?.hide()
+        }
         ModalNavigationDrawer(
-            drawerState = kaigiAppScaffoldState.drawerState,
+            drawerState = drawerState,
             drawerContent = { ModalDrawerSheet { drawerSheetContent() } },
         ) {
             content()


### PR DESCRIPTION
## Issue
- close #551 

## Overview (Required)
- hide the software keyboard when the drawer menu starts expanding.

## Links
- Nothing.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5121183/190914034-07e8aa72-f943-432a-96d0-f8628dedad25.gif" width="200" /> | <img src="https://user-images.githubusercontent.com/5121183/190914051-8d8abe27-0439-4609-af0a-1f843a39d34f.gif" width="200" />