### PR TITLE
Use explicitApi in core-model

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2022.core.model"
 
 kotlin {
-    explicitApiWarning()
+    explicitApi()
 
     sourceSets {
         val commonMain by getting {

--- a/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
+++ b/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
@@ -1,3 +1,3 @@
 package io.github.droidkaigi.confsched2022.model
 
-actual typealias Immutable = androidx.compose.runtime.Immutable
+public actual typealias Immutable = androidx.compose.runtime.Immutable

--- a/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
+++ b/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2022.model
 
-actual fun getDefaultLocale(): Locale =
+public actual fun getDefaultLocale(): Locale =
     if (java.util.Locale.getDefault() == java.util.Locale.JAPAN) {
         Locale.JAPAN
     } else {

--- a/core/model/src/androidTest/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
+++ b/core/model/src/androidTest/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
@@ -1,3 +1,3 @@
 package io.github.droidkaigi.confsched2022.model
 
-actual annotation class Immutable
+public actual annotation class Immutable

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/AppError.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/AppError.kt
@@ -1,23 +1,23 @@
 package io.github.droidkaigi.confsched2022.model
 
-sealed class AppError : RuntimeException {
-    constructor()
-    constructor(message: String?) : super(message)
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
-    constructor(cause: Throwable?) : super(cause)
+public sealed class AppError : RuntimeException {
+    private constructor()
+    private constructor(message: String?) : super(message)
+    private constructor(message: String?, cause: Throwable?) : super(message, cause)
+    private constructor(cause: Throwable?) : super(cause)
 
-    sealed class ApiException(cause: Throwable?) : AppError(cause) {
-        class NetworkException(cause: Throwable?) : ApiException(cause)
-        class ServerException(cause: Throwable?) : ApiException(cause)
-        class TimeoutException(cause: Throwable?) : ApiException(cause)
-        class SessionNotFoundException(cause: Throwable?) : AppError(cause)
-        class UnknownException(cause: Throwable?) : AppError(cause)
+    public sealed class ApiException(cause: Throwable?) : AppError(cause) {
+        public class NetworkException(cause: Throwable?) : ApiException(cause)
+        public class ServerException(cause: Throwable?) : ApiException(cause)
+        public class TimeoutException(cause: Throwable?) : ApiException(cause)
+        public class SessionNotFoundException(cause: Throwable?) : AppError(cause)
+        public class UnknownException(cause: Throwable?) : AppError(cause)
     }
 
-    sealed class ExternalIntegrationError(cause: Throwable?) : AppError(cause) {
-        class NoCalendarIntegrationFoundException(cause: Throwable?) :
+    public sealed class ExternalIntegrationError(cause: Throwable?) : AppError(cause) {
+        public class NoCalendarIntegrationFoundException(cause: Throwable?) :
             ExternalIntegrationError(cause)
     }
 
-    class UnknownException(cause: Throwable?) : AppError(cause)
+    public class UnknownException(cause: Throwable?) : AppError(cause)
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Contributor.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Contributor.kt
@@ -3,16 +3,16 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
-data class Contributor(
+public data class Contributor(
     val id: Int,
     val username: String,
     val profileUrl: String?,
     val iconUrl: String,
 ) {
-    companion object
+    public companion object
 }
 
-fun Contributor.Companion.fakes(): PersistentList<Contributor> = persistentListOf(
+public fun Contributor.Companion.fakes(): PersistentList<Contributor> = persistentListOf(
     Contributor(
         id = 1,
         username = "Pie",

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/ContributorsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/ContributorsRepository.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
 
-interface ContributorsRepository {
-    fun contributors(): Flow<PersistentList<Contributor>>
-    suspend fun refresh()
+public interface ContributorsRepository {
+    public fun contributors(): Flow<PersistentList<Contributor>>
+    public suspend fun refresh()
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/DroidKaigi2022Day.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/DroidKaigi2022Day.kt
@@ -5,7 +5,10 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 
-enum class DroidKaigi2022Day(val start: Instant, val end: Instant) {
+public enum class DroidKaigi2022Day(
+    public val start: Instant,
+    public val end: Instant
+) {
     Day1(
         start = LocalDateTime
             .parse("2022-10-05T00:00:00")
@@ -31,8 +34,8 @@ enum class DroidKaigi2022Day(val start: Instant, val end: Instant) {
             .toInstant(TimeZone.of("UTC+9"))
     );
 
-    companion object {
-        fun ofOrNull(time: Instant): DroidKaigi2022Day? {
+    public companion object {
+        public fun ofOrNull(time: Instant): DroidKaigi2022Day? {
             return values().firstOrNull() {
                 time in it.start..it.end
             }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/DroidKaigiSchedule.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/DroidKaigiSchedule.kt
@@ -10,12 +10,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 
 @Serializable
-data class DroidKaigiSchedule(
+public data class DroidKaigiSchedule(
     val dayToTimetable: PersistentMap<DroidKaigi2022Day, Timetable>,
     private val timetable: Timetable
 ) {
-    val days = DroidKaigi2022Day.values()
-    fun filtered(value: Filters): DroidKaigiSchedule {
+    val days: Array<DroidKaigi2022Day> = DroidKaigi2022Day.values()
+    public fun filtered(value: Filters): DroidKaigiSchedule {
         return DroidKaigiSchedule(
             dayToTimetable = dayToTimetable
                 .mapValues { it.value.filtered(value) }
@@ -24,12 +24,12 @@ data class DroidKaigiSchedule(
         )
     }
 
-    fun findTimetableItem(id: TimetableItemId): TimetableItemWithFavorite {
+    public fun findTimetableItem(id: TimetableItemId): TimetableItemWithFavorite {
         return timetable.contents.first { id == it.timetableItem.id }
     }
 
-    companion object {
-        fun of(timetable: Timetable): DroidKaigiSchedule {
+    public companion object {
+        public fun of(timetable: Timetable): DroidKaigiSchedule {
             return DroidKaigiSchedule(
                 DroidKaigi2022Day.values().associateWith { day ->
                     timetable.dayTimetable(day)
@@ -40,6 +40,6 @@ data class DroidKaigiSchedule(
     }
 }
 
-fun DroidKaigiSchedule.Companion.fake(): DroidKaigiSchedule {
+public fun DroidKaigiSchedule.Companion.fake(): DroidKaigiSchedule {
     return of(Timetable.fake())
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Filters.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Filters.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2022.model
 
-data class Filters(
+public data class Filters(
     val filterFavorite: Boolean = false,
     val filterSession: Boolean = false,
     val searchWord: String = ""

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
@@ -1,3 +1,3 @@
 package io.github.droidkaigi.confsched2022.model
 
-expect annotation class Immutable()
+public expect annotation class Immutable()

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Lang.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Lang.kt
@@ -4,18 +4,18 @@ import io.github.droidkaigi.confsched2022.model.Lang.ENGLISH
 import io.github.droidkaigi.confsched2022.model.Lang.JAPANESE
 import io.github.droidkaigi.confsched2022.model.Lang.MIXED
 
-enum class Lang(
-    val tagName: String,
-    val backgroundColor: Long,
+public enum class Lang(
+    public val tagName: String,
+    public val backgroundColor: Long,
 ) {
     MIXED("MIXED", backgroundColor = 0xFF7056BB),
     JAPANESE("JA", backgroundColor = 0xFF48A8DA),
     ENGLISH("EN", backgroundColor = 0xFF6ACA8F);
 }
 
-fun defaultLang() = if (getDefaultLocale() == Locale.JAPAN) JAPANESE else ENGLISH
+public fun defaultLang(): Lang = if (getDefaultLocale() == Locale.JAPAN) JAPANESE else ENGLISH
 
-fun Lang.secondLang(): Lang? = when (this) {
+public fun Lang.secondLang(): Lang? = when (this) {
     MIXED -> null
     JAPANESE -> ENGLISH
     ENGLISH -> JAPANESE

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
@@ -1,8 +1,8 @@
 package io.github.droidkaigi.confsched2022.model
 
-enum class Locale {
+public enum class Locale {
     JAPAN,
     OTHER
 }
 
-expect fun getDefaultLocale(): Locale
+public expect fun getDefaultLocale(): Locale

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/MultiLangText.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/MultiLangText.kt
@@ -3,13 +3,13 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MultiLangText(
+public data class MultiLangText(
     val jaTitle: String,
     val enTitle: String,
 ) {
-    val currentLangTitle get() = getByLang(defaultLang())
+    val currentLangTitle: String get() = getByLang(defaultLang())
 
-    fun getByLang(lang: Lang): String {
+    private fun getByLang(lang: Lang): String {
         return if (lang == Lang.JAPANESE) {
             jaTitle
         } else {
@@ -17,5 +17,5 @@ data class MultiLangText(
         }
     }
 
-    companion object
+    public companion object
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/PersistentListSerializer.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/PersistentListSerializer.kt
@@ -18,16 +18,16 @@ import kotlinx.serialization.encoding.Encoder
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializer(forClass = PersistentList::class)
-class PersistentListSerializer(
+public class PersistentListSerializer(
     private val dataSerializer: KSerializer<String>
 ) :
     KSerializer<PersistentList<String>> {
-    class PersistentListDescriptor : SerialDescriptor by serialDescriptor<List<String>>() {
+    public class PersistentListDescriptor : SerialDescriptor by serialDescriptor<List<String>>() {
         @ExperimentalSerializationApi override val serialName: String =
             "kotlinx.serialization.immutable.persistentList"
     }
 
-    override val descriptor = PersistentListDescriptor()
+    override val descriptor: PersistentListDescriptor = PersistentListDescriptor()
     override fun serialize(encoder: Encoder, value: PersistentList<String>) {
         return ListSerializer(dataSerializer).serialize(encoder, value.toList())
     }
@@ -39,16 +39,16 @@ class PersistentListSerializer(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializer(forClass = PersistentSet::class)
-class PersistentSetSerializer(
+public class PersistentSetSerializer(
     private val dataSerializer: KSerializer<String>
 ) :
     KSerializer<PersistentSet<String>> {
-    class PersistentSetDescriptor : SerialDescriptor by serialDescriptor<List<String>>() {
+    public class PersistentSetDescriptor : SerialDescriptor by serialDescriptor<List<String>>() {
         @ExperimentalSerializationApi override val serialName: String =
             "kotlinx.serialization.immutable.persistentList"
     }
 
-    override val descriptor = PersistentSetDescriptor()
+    override val descriptor: PersistentSetDescriptor = PersistentSetDescriptor()
     override fun serialize(encoder: Encoder, value: PersistentSet<String>) {
         return ListSerializer(dataSerializer).serialize(encoder, value.toList())
     }
@@ -60,17 +60,18 @@ class PersistentSetSerializer(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializer(forClass = PersistentMap::class)
-class PersistentMapSerializer(
+public class PersistentMapSerializer(
     private val data1Serializer: KSerializer<String>,
     private val data2Serializer: KSerializer<String>
 ) :
     KSerializer<PersistentMap<String, String>> {
-    class PersistentMapDescriptor : SerialDescriptor by serialDescriptor<Map<String, String>>() {
+    public class PersistentMapDescriptor :
+        SerialDescriptor by serialDescriptor<Map<String, String>>() {
         @ExperimentalSerializationApi override val serialName: String =
             "kotlinx.serialization.immutable.persistentList"
     }
 
-    override val descriptor = PersistentMapDescriptor()
+    override val descriptor: PersistentMapDescriptor = PersistentMapDescriptor()
     override fun serialize(encoder: Encoder, value: PersistentMap<String, String>) {
         return MapSerializer(data1Serializer, data2Serializer).serialize(encoder, value.toMap())
     }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/SessionsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/SessionsRepository.kt
@@ -3,14 +3,16 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-interface SessionsRepository {
-    fun droidKaigiScheduleFlow(): Flow<DroidKaigiSchedule>
+public interface SessionsRepository {
+    public fun droidKaigiScheduleFlow(): Flow<DroidKaigiSchedule>
 
-    fun timetableItemFlow(timetableItemId: TimetableItemId): Flow<TimetableItemWithFavorite> {
+    public fun timetableItemFlow(
+        timetableItemId: TimetableItemId
+    ): Flow<TimetableItemWithFavorite> {
         return droidKaigiScheduleFlow()
             .map { it.findTimetableItem(timetableItemId) }
     }
 
-    suspend fun refresh()
-    suspend fun setFavorite(sessionId: TimetableItemId, favorite: Boolean)
+    public suspend fun refresh()
+    public suspend fun setFavorite(sessionId: TimetableItemId, favorite: Boolean)
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Staff.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Staff.kt
@@ -3,16 +3,16 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
-data class Staff(
+public data class Staff(
     val id: Int,
     val username: String,
     val profileUrl: String,
     val iconUrl: String
 ) {
-    companion object
+    public companion object
 }
 
-fun Staff.Companion.fakes(): PersistentList<Staff> = persistentListOf(
+public fun Staff.Companion.fakes(): PersistentList<Staff> = persistentListOf(
     Staff(
         id = 1,
         username = "staffA",

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/StaffRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/StaffRepository.kt
@@ -3,6 +3,6 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
 
-interface StaffRepository {
-    fun staff(): Flow<PersistentList<Staff>>
+public interface StaffRepository {
+    public fun staff(): Flow<PersistentList<Staff>>
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/Timetable.kt
@@ -18,21 +18,21 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 
 @Serializable
-data class Timetable(
+public data class Timetable(
     val timetableItems: TimetableItemList = TimetableItemList(),
     val favorites: PersistentSet<TimetableItemId> = persistentSetOf(),
 ) {
-    val contents by lazy {
+    val contents: List<TimetableItemWithFavorite> by lazy {
         timetableItems.map {
             TimetableItemWithFavorite(it, favorites.contains(it.id))
         }
     }
 
-    val rooms by lazy {
+    val rooms: List<TimetableRoom> by lazy {
         timetableItems.map { it.room }.toSet().sortedBy { it.sort }
     }
 
-    fun dayTimetable(droidKaigi2022Day: DroidKaigi2022Day): Timetable {
+    public fun dayTimetable(droidKaigi2022Day: DroidKaigi2022Day): Timetable {
         var timetableItems = timetableItems.toList()
         timetableItems = timetableItems.filter { timetableItem ->
             timetableItem.day == droidKaigi2022Day
@@ -40,7 +40,7 @@ data class Timetable(
         return copy(timetableItems = TimetableItemList(timetableItems.toPersistentList()))
     }
 
-    fun filtered(filters: Filters): Timetable {
+    public fun filtered(filters: Filters): Timetable {
         var timetableItems = timetableItems.toList()
         if (filters.filterFavorite) {
             timetableItems = timetableItems.filter { timetableItem ->
@@ -58,16 +58,16 @@ data class Timetable(
         return copy(timetableItems = TimetableItemList(timetableItems.toPersistentList()))
     }
 
-    fun isEmpty(): Boolean {
+    public fun isEmpty(): Boolean {
         return timetableItems.isEmpty()
     }
 
-    companion object
+    public companion object
 }
 
-fun Timetable?.orEmptyContents(): Timetable = this ?: Timetable()
+public fun Timetable?.orEmptyContents(): Timetable = this ?: Timetable()
 
-fun Timetable.Companion.fake(): Timetable {
+public fun Timetable.Companion.fake(): Timetable {
     var rooms = listOf(
         TimetableRoom(0, MultiLangText("App Bar", "App Bar"), 0),
         TimetableRoom(1, MultiLangText("Backdrop", "Backdrop"), 1),

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableAsset.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableAsset.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TimetableAsset(
+public data class TimetableAsset(
     val videoUrl: String?,
     val slideUrl: String?,
 )

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableCategory.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableCategory.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TimetableCategory(
+public data class TimetableCategory(
     val id: Int,
     val title: MultiLangText,
 )

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItem.kt
@@ -17,21 +17,21 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 
 @Serializable
-sealed class TimetableItem {
-    abstract val id: TimetableItemId
-    abstract val title: MultiLangText
-    abstract val startsAt: Instant
-    abstract val endsAt: Instant
-    abstract val category: TimetableCategory
-    abstract val room: TimetableRoom
-    abstract val targetAudience: String
-    abstract val language: TimetableLanguage
-    abstract val asset: TimetableAsset
-    abstract val levels: PersistentList<String>
-    val day: DroidKaigi2022Day? get() = DroidKaigi2022Day.ofOrNull(startsAt)
+public sealed class TimetableItem {
+    public abstract val id: TimetableItemId
+    public abstract val title: MultiLangText
+    public abstract val startsAt: Instant
+    public abstract val endsAt: Instant
+    public abstract val category: TimetableCategory
+    public abstract val room: TimetableRoom
+    public abstract val targetAudience: String
+    public abstract val language: TimetableLanguage
+    public abstract val asset: TimetableAsset
+    public abstract val levels: PersistentList<String>
+    public val day: DroidKaigi2022Day? get() = DroidKaigi2022Day.ofOrNull(startsAt)
 
     @Serializable
-    data class Session(
+    public data class Session(
         override val id: TimetableItemId,
         override val title: MultiLangText,
         override val startsAt: Instant,
@@ -46,11 +46,11 @@ sealed class TimetableItem {
         val speakers: PersistentList<TimetableSpeaker>,
         val message: MultiLangText?,
     ) : TimetableItem() {
-        companion object
+        public companion object
     }
 
     @Serializable
-    data class Special(
+    public data class Special(
         override val id: TimetableItemId,
         override val title: MultiLangText,
         override val startsAt: Instant,
@@ -64,19 +64,19 @@ sealed class TimetableItem {
         val speakers: PersistentList<TimetableSpeaker> = persistentListOf(),
     ) : TimetableItem()
 
-    val startsTimeString: String by lazy {
+    public val startsTimeString: String by lazy {
         val localDate = startsAt.toLocalDateTime(TimeZone.currentSystemDefault())
         "${localDate.hour}".padStart(2, '0') + ":" + "${localDate.minute}".padStart(2, '0')
     }
 
-    val minutesString: String by lazy {
+    public val minutesString: String by lazy {
         val minutes = (endsAt - startsAt)
             .toComponents { minutes, _, _ -> minutes }
         "${minutes}min"
     }
 }
 
-fun TimetableItem.Session.Companion.fake(): Session {
+public fun TimetableItem.Session.Companion.fake(): Session {
     return Session(
         id = TimetableItemId("2"),
         title = MultiLangText("DroidKaigiのアプリのアーキテクチャ", "DroidKaigi App Architecture"),

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItemId.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItemId.kt
@@ -3,4 +3,4 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TimetableItemId(val value: String)
+public data class TimetableItemId(val value: String)

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItemList.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItemList.kt
@@ -11,10 +11,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 
 @Serializable
-data class TimetableItemList(
+public data class TimetableItemList(
     val timetableItems: PersistentList<TimetableItem> = persistentListOf(),
 ) : PersistentList<TimetableItem> by timetableItems {
-    fun getDayTimetableItems(day: DroidKaigi2022Day): TimetableItemList {
+    public fun getDayTimetableItems(day: DroidKaigi2022Day): TimetableItemList {
         return TimetableItemList(
             timetableItems.filter {
                 it.startsAt in day.start..day.end

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItemWithFavorite.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableItemWithFavorite.kt
@@ -2,10 +2,13 @@ package io.github.droidkaigi.confsched2022.model
 
 import io.github.droidkaigi.confsched2022.model.TimetableItem.Session
 
-data class TimetableItemWithFavorite(val timetableItem: TimetableItem, val isFavorited: Boolean) {
-    companion object
+public data class TimetableItemWithFavorite(
+    val timetableItem: TimetableItem,
+    val isFavorited: Boolean
+) {
+    public companion object
 }
 
-fun TimetableItemWithFavorite.Companion.fake(): TimetableItemWithFavorite {
+public fun TimetableItemWithFavorite.Companion.fake(): TimetableItemWithFavorite {
     return TimetableItemWithFavorite(Session.fake(), true)
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableLanguage.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableLanguage.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TimetableLanguage(
+public data class TimetableLanguage(
     val langOfSpeaker: String,
     val isInterpretationTarget: Boolean,
 )

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableRoom.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableRoom.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TimetableRoom(
+public data class TimetableRoom(
     val id: Int,
     val name: MultiLangText,
     val sort: Int

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableSpeaker.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/TimetableSpeaker.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2022.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TimetableSpeaker(
+public data class TimetableSpeaker(
     val id: String,
     val name: String,
     val iconUrl: String,

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/strings/ResExt.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/strings/ResExt.kt
@@ -3,5 +3,5 @@ package io.github.droidkaigi.confsched2022.strings
 import io.github.droidkaigi.confsched2022.model.Res
 import io.github.droidkaigi.confsched2022.model.Res.strings
 
-val Strings: strings
+public val Strings: strings
     get() = Res.strings

--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
@@ -1,3 +1,3 @@
 package io.github.droidkaigi.confsched2022.model
 
-actual annotation class Immutable
+public actual annotation class Immutable

--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
@@ -4,7 +4,7 @@ import platform.Foundation.NSLocale
 import platform.Foundation.countryCode
 import platform.Foundation.currentLocale
 
-actual fun getDefaultLocale(): Locale =
+public actual fun getDefaultLocale(): Locale =
     if (NSLocale.currentLocale.countryCode == "JP") {
         Locale.JAPAN
     } else {

--- a/core/model/src/jsMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
+++ b/core/model/src/jsMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
@@ -1,3 +1,3 @@
 package io.github.droidkaigi.confsched2022.model
 
-actual annotation class Immutable
+public actual annotation class Immutable

--- a/core/model/src/jsMain/kotlin/io/github/droidkaigi/confsched2022/model/getDefaultLocale.kt
+++ b/core/model/src/jsMain/kotlin/io/github/droidkaigi/confsched2022/model/getDefaultLocale.kt
@@ -4,7 +4,7 @@ import io.github.droidkaigi.confsched2022.model.Locale.JAPAN
 import io.github.droidkaigi.confsched2022.model.Locale.OTHER
 import kotlinx.browser.window
 
-actual fun getDefaultLocale(): Locale {
+public actual fun getDefaultLocale(): Locale {
     if (window.navigator.language.contains("JP", ignoreCase = true)) {
         return JAPAN
     }


### PR DESCRIPTION
## Issue
- close #566

## Overview (Required)
- Use explicitApi() instead of explicitApiWarning() in core-model
- Set access modifiers in core-model


## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
