### PR TITLE
[iOS] Add Caching support to network image

### DIFF
--- a/app-ios/DroidKaigi2022/DroidKaigi2022.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app-ios/DroidKaigi2022/DroidKaigi2022.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher",
+      "state" : {
+        "revision" : "be1a1acb283a702b99b630f586877ba02234b4cb",
+        "version" : "7.3.2"
+      }
+    },
+    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",

--- a/app-ios/Package.swift
+++ b/app-ios/Package.swift
@@ -32,6 +32,7 @@ var package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "9.6.0"),
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.40.2"),
         .package(url: "https://github.com/cybozu/LicenseList", from: "0.1.5"),
+        .package(url: "https://github.com/onevcat/Kingfisher", from: "7.3.2"),
     ],
     targets: [
         .target(
@@ -97,6 +98,7 @@ var package = Package(
                 .target(name: "Assets"),
                 .target(name: "Model"),
                 .target(name: "Theme"),
+                .product(name: "Kingfisher", package: "Kingfisher"),
             ]
         ),
         .target(

--- a/app-ios/Package.swift
+++ b/app-ios/Package.swift
@@ -153,6 +153,7 @@ var package = Package(
             dependencies: [
                 .target(name: "appioscombined"),
                 .target(name: "Assets"),
+                .target(name: "CommonComponents"),
                 .target(name: "Model"),
                 .target(name: "Theme"),
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),

--- a/app-ios/Package.swift
+++ b/app-ios/Package.swift
@@ -112,6 +112,7 @@ var package = Package(
             name: "ContributorFeature",
             dependencies: [
                 .target(name: "Assets"),
+                .target(name: "CommonComponents"),
                 .target(name: "Model"),
                 .target(name: "Strings"),
                 .target(name: "Theme"),

--- a/app-ios/Sources/AboutFeature/license-list.plist
+++ b/app-ios/Sources/AboutFeature/license-list.plist
@@ -1809,6 +1809,36 @@ Fuller's blog&lt;/a&gt;
 		</dict>
 		<dict>
 			<key>licenseBody</key>
+			<string>The MIT License (MIT)
+
+Copyright (c) 2019 Wei Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+</string>
+			<key>licenseType</key>
+			<string>MIT License</string>
+			<key>name</key>
+			<string>Kingfisher</string>
+		</dict>
+		<dict>
+			<key>licenseBody</key>
 			<string>Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/app-ios/Sources/CommonComponents/NetworkImage.swift
+++ b/app-ios/Sources/CommonComponents/NetworkImage.swift
@@ -4,6 +4,7 @@ import Kingfisher
 public struct NetworkImage: View {
 
     public let url: URL?
+    public let contentMode: SwiftUI.ContentMode
     public let placeholder: (() -> AnyView)?
     public let failure: ((KingfisherError) -> AnyView)?
 
@@ -13,14 +14,16 @@ public struct NetworkImage: View {
 
     @State private var error: KingfisherError?
 
-    init(
+    public init(
         url: URL?,
+        contentMode: SwiftUI.ContentMode = .fill,
         enableCache: Bool = true,
         cacheInMemory: Bool = true,
         placeholder: (() -> AnyView)? = nil,
         failure: ((KingfisherError) -> AnyView)? = nil
     ) {
         self.url = url
+        self.contentMode = contentMode
         self.enableCache = enableCache
         self.cacheInMemory = cacheInMemory
         self.placeholder = placeholder
@@ -39,6 +42,7 @@ public struct NetworkImage: View {
                 .onFailure { error in
                     self.error = error
                 }
+                .aspectRatio(contentMode: contentMode)
         }
     }
 }

--- a/app-ios/Sources/CommonComponents/NetworkImage.swift
+++ b/app-ios/Sources/CommonComponents/NetworkImage.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import Kingfisher
+
+public struct NetworkImage: View {
+
+    public let url: URL
+    public let placeholder: (() -> AnyView)?
+    public let failure: ((KingfisherError) -> AnyView)?
+
+    // cache settings
+    public let enableCache: Bool
+    public let cacheInMemory: Bool
+
+    @State private var error: KingfisherError?
+
+    init(
+        url: URL,
+        enableCache: Bool = true,
+        cacheInMemory: Bool = true,
+        placeholder: (() -> AnyView)? = nil,
+        failure: ((KingfisherError) -> AnyView)? = nil
+    ) {
+        self.url = url
+        self.enableCache = enableCache
+        self.cacheInMemory = cacheInMemory
+        self.placeholder = placeholder
+        self.failure = failure
+    }
+
+    public var body: some View {
+        if let error = error, let failure = failure {
+            failure(error)
+        } else {
+            KFImage(url)
+                .wrapPlaceholder(placeholder)
+                .cacheOriginalImage(enableCache)
+                .cacheMemoryOnly(cacheInMemory)
+                .resizable()
+                .onFailure { error in
+                    self.error = error
+                }
+        }
+    }
+}
+
+private extension KFImage {
+    func wrapPlaceholder(_ placeholder: (() -> AnyView)?) -> KFImage {
+        if let placeholder = placeholder {
+            return self.placeholder(placeholder)
+        } else {
+            return self
+        }
+    }
+}
+
+#if DEBUG
+struct NetworkImage_Previews: PreviewProvider {
+    static var previews: some View {
+        // DroidKaigi Icon
+        let imageURL = URL(string: "https://avatars.githubusercontent.com/u/10727543?s=200&v=4")!
+        ScrollView {
+            LazyVGrid(columns: [.init(), .init()]) {
+                ForEach(0..<100, id: \.self) { _ in
+                    NetworkImage(url: imageURL)
+                        .frame(width: 120, height: 120)
+                }
+            }
+        }
+        .previewDisplayName("Success")
+
+        let invalidImageURL = URL(string: "https://")!
+        ScrollView {
+            LazyVGrid(columns: [.init(), .init()]) {
+                ForEach(0..<100, id: \.self) { _ in
+                    NetworkImage(
+                        url: invalidImageURL,
+                        failure:  { error in
+                            AnyView(Color.red)
+                        }
+                    )
+                    .frame(width: 120, height: 120)
+                }
+            }
+        }
+        .previewDisplayName("Fail")
+    }
+}
+#endif

--- a/app-ios/Sources/CommonComponents/NetworkImage.swift
+++ b/app-ios/Sources/CommonComponents/NetworkImage.swift
@@ -3,14 +3,14 @@ import Kingfisher
 
 public struct NetworkImage: View {
 
-    public let url: URL?
-    public let contentMode: SwiftUI.ContentMode
-    public let placeholder: (() -> AnyView)?
-    public let failure: ((KingfisherError) -> AnyView)?
+    let url: URL?
+    let contentMode: SwiftUI.ContentMode
+    let placeholder: (() -> AnyView)?
+    let failure: ((KingfisherError) -> AnyView)?
 
     // cache settings
-    public let enableCache: Bool
-    public let cacheInMemory: Bool
+    let enableCache: Bool
+    let cacheInMemory: Bool
 
     @State private var error: KingfisherError?
 

--- a/app-ios/Sources/CommonComponents/NetworkImage.swift
+++ b/app-ios/Sources/CommonComponents/NetworkImage.swift
@@ -3,7 +3,7 @@ import Kingfisher
 
 public struct NetworkImage: View {
 
-    public let url: URL
+    public let url: URL?
     public let placeholder: (() -> AnyView)?
     public let failure: ((KingfisherError) -> AnyView)?
 
@@ -14,7 +14,7 @@ public struct NetworkImage: View {
     @State private var error: KingfisherError?
 
     init(
-        url: URL,
+        url: URL?,
         enableCache: Bool = true,
         cacheInMemory: Bool = true,
         placeholder: (() -> AnyView)? = nil,
@@ -57,7 +57,7 @@ private extension KFImage {
 struct NetworkImage_Previews: PreviewProvider {
     static var previews: some View {
         // DroidKaigi Icon
-        let imageURL = URL(string: "https://avatars.githubusercontent.com/u/10727543?s=200&v=4")!
+        let imageURL = URL(string: "https://avatars.githubusercontent.com/u/10727543?s=200&v=4")
         ScrollView {
             LazyVGrid(columns: [.init(), .init()]) {
                 ForEach(0..<100, id: \.self) { _ in
@@ -68,7 +68,7 @@ struct NetworkImage_Previews: PreviewProvider {
         }
         .previewDisplayName("Success")
 
-        let invalidImageURL = URL(string: "https://")!
+        let invalidImageURL = URL(string: "https://")
         ScrollView {
             LazyVGrid(columns: [.init(), .init()]) {
                 ForEach(0..<100, id: \.self) { _ in

--- a/app-ios/Sources/CommonComponents/PersonLabel.swift
+++ b/app-ios/Sources/CommonComponents/PersonLabel.swift
@@ -7,18 +7,11 @@ struct PersonLabel: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
-            AsyncImage(
-                url: URL(string: iconUrl),
-                content: { image in
-                    image
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                        .clipShape(Circle())
-                }, placeholder: {
-                    Circle()
-                        .frame(width: 24, height: 24)
-                }
-            )
+            NetworkImage(url: URL(string: iconUrl)) {
+                AnyView(Circle())
+            }
+            .frame(width: 24, height: 24)
+            .clipShape(Circle())
             Text(name)
                 .font(Font.system(size: 12, weight: .medium))
                 .frame(height: 16)

--- a/app-ios/Sources/ContributorFeature/ContributorView.swift
+++ b/app-ios/Sources/ContributorFeature/ContributorView.swift
@@ -1,4 +1,5 @@
 import Assets
+import CommonComponents
 import ComposableArchitecture
 import Model
 import Strings
@@ -91,10 +92,8 @@ struct ContributorItemView: View {
     var body: some View {
         ZStack {
             HStack(spacing: 16) {
-                AsyncImage(url: URL(string: contributor.iconUrl)) { image in
-                    image.resizable()
-                } placeholder: {
-                    Color(.systemGray4)
+                NetworkImage(url: URL(string: contributor.iconUrl)) {
+                    AnyView(Color(.systemGray4))
                 }
                 .frame(width: 60, height: 60)
                 .clipShape(Circle())

--- a/app-ios/Sources/SessionFeature/SessionSpeakersView.swift
+++ b/app-ios/Sources/SessionFeature/SessionSpeakersView.swift
@@ -1,4 +1,5 @@
 import appioscombined
+import CommonComponents
 import Strings
 import SwiftUI
 import Theme
@@ -15,15 +16,11 @@ struct SessionSpeakersView: View {
 
             ForEach(self.speakers, id: \.self) { speaker in
                 HStack {
-                    AsyncImage(
-                        url: URL(string: speaker.iconUrl),
-                        content: {
-                            $0.image?.resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 60, height: 60)
-                                .clipShape(Circle())
-                        }
+                    NetworkImage(
+                        url: URL(string: speaker.iconUrl)
                     )
+                    .frame(width: 60, height: 60)
+                    .clipShape(Circle())
                     .padding(.trailing)
                     Text(speaker.name)
                         .font(Font.system(size: 16, weight: .regular, design: .default))


### PR DESCRIPTION
## Issue
- close #547 

## Overview (Required)
Add image cache support with [Kingfisher](https://github.com/onevcat/Kingfisher)

- Create NetworkImage
- Replace AsyncImage with NetworkImage
   Replace in
    - CommonComponents/PersonLabel
    - ContributorFeature/ContributorView
    - SessionFeature/SessionSpeakersView

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/44002126/190961573-efedf76c-f942-4b9a-94dc-2601041a230d.png" width="300" /> | <img src="https://user-images.githubusercontent.com/44002126/190961129-c8e7d7bd-98a4-4797-ae77-e9eebae6e74f.png" width="300" />
<img src="https://user-images.githubusercontent.com/44002126/190961575-dc04c2c2-5ddb-4879-9bca-284915323def.png" width="300" /> | <img src="https://user-images.githubusercontent.com/44002126/190961145-041122c7-243a-41e0-8654-cc39401244c9.png" width="300" />
<img src="https://user-images.githubusercontent.com/44002126/190961579-c2969158-94e9-494b-b502-ffdbe47c9a8b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/44002126/190961139-6b99c97f-677d-4f40-b077-bb99f776ecd2.png" width="300" />

