### PR TITLE
Remove an unnecessary workaround fixing the version of javapoet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,3 @@ plugins {
     alias(libs.plugins.kotlinPlugin) apply false
     id("droidkaigi.primitive.dependencygraph")
 }
-buildscript {
-    configurations.all {
-        resolutionStrategy.eachDependency {
-            when {
-                requested.name == "javapoet" -> useVersion("1.13.0")
-            }
-        }
-    }
-}


### PR DESCRIPTION
## Issue
- No issue

## Overview (Required)
- When I looked at the build script, I found a description that seemed unnecessary.


### Dependency diff

```
# With `resolutionStrategy`
$ ./gradlew :app-android:dependencies --configuration kapt | grep javapoet
     |    |    +--- com.squareup:javapoet:1.13.0
     |    +--- com.squareup:javapoet:1.13.0
     +--- com.squareup:javapoet:1.13.0

# Without `resolutionStrategy`
$ ./gradlew :app-android:dependencies --configuration kapt | grep javapoet
     |    |    +--- com.squareup:javapoet:1.13.0
     |    +--- com.squareup:javapoet:1.13.0
     +--- com.squareup:javapoet:1.13.0
```