### PR TITLE
Apply search day header design

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -183,7 +183,7 @@ private fun SearchedItemListField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable { onItemClick(timetableItemWithFavorite.timetableItem.id) }
-                        .padding(12.dp)
+                        .padding(16.dp)
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth()
@@ -233,17 +233,15 @@ private fun SearchedItemListField(
 
 @Composable
 private fun SearchedHeader(day: DroidKaigi2022Day, modifier: Modifier = Modifier) {
-    Column(
+    Text(
+        text = day.name,
         modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight()
-            .background(MaterialTheme.colorScheme.onPrimary)
-    ) {
-        Text(
-            text = day.name,
-            modifier = Modifier.padding(top = 10.dp, bottom = 10.dp, start = 10.dp)
-        )
-    }
+            .background(color = MaterialTheme.colorScheme.background)
+            .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 16.dp),
+        style = MaterialTheme.typography.titleLarge
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2022/issues/596

## Overview (Required)
- Apply search day header design

## Links
- Design: https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1

## Screenshot
Before | After
:--: | :--:
[device-2022-09-19-183848.webm](https://user-images.githubusercontent.com/23094546/190991338-a5d1ff2b-6304-43e5-ac88-86f8d30b875c.webm) | [device-2022-09-19-184140.webm](https://user-images.githubusercontent.com/23094546/190991412-4f5ea58d-00b6-4f1e-8cda-ac97616f849c.webm)

