### PR TITLE
Send comment PR for failed screenshot tests.

### DIFF
--- a/.github/workflows/ScreenShotTest.yml
+++ b/.github/workflows/ScreenShotTest.yml
@@ -43,15 +43,52 @@ jobs:
         if: ${{ hashFiles('preview-screenshots/out/failures/*.png') != '' }}
         uses: actions/upload-artifact@v3
         with:
-          name: scrennshot-test-results
+          name: screenshot-test-results
           path: preview-screenshots/out/failures
 
-      - name: Comment PR
+      - name: Checkout the docs branch
+        id: checkout_docs
         if: ${{ hashFiles('preview-screenshots/out/failures/*.png') != '' }}
+        uses: actions/checkout@v3
+        with:
+          path: temp_docs
+          ref: docs
+
+      - name: Commit the screenshot to the branch
+        id: docs_images
+        if: steps.checkout_docs.outcome == 'success'
         continue-on-error: true # https://github.com/DroidKaigi/conference-app-2022/issues/497
+        run: |
+          cp -a preview-screenshots/out/failures/. temp_docs/docs/screenshots/
+          cd temp_docs/
+          if ! git diff --exit-code --quiet
+          then
+            git add . --update
+            git commit -m "Upload screenshots to github page."
+            git push
+            sleep 3 # wait 3 minutes for github page to update
+          fi
+          cd ..
+          cd preview-screenshots/out/failures
+          echo ::set-output name=images::$(ls | jq -R -s -c 'split("\n")[:-1]' | jq -r '.[] |= "https://droidkaigi.github.io/conference-app-2022/screenshots/" + .')
+
+      - name: Build PR Comment with Preview
+        id: pr_comment
+        if: steps.docs_images.outcome == 'success'
+        continue-on-error: true # https://github.com/DroidKaigi/conference-app-2022/issues/497
+        env:
+          ALL_SCREENSHOTS: ${{ steps.docs_images.outputs.images }}
+        # Build a comment message with the image from snapshot images for demo purpose.
+        run: |
+          echo "There are differences in Compose previews." > report.md
+          echo "$ALL_SCREENSHOTS" | jq -r '.[]' | while read -r image; do 
+            echo "![]($image)" >> report.md
+          done
+          echo ::set-output name=comment::$(cat report.md)
+
+      - name: Comment PR
+        if: steps.pr_comment.outcome == 'success'
         uses: thollander/actions-comment-pull-request@v1
         with:
-          message: |
-            There are differences in Compose previews. Please check your build and download the diff artifact.
-            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          message: ${{ steps.pr_comment.outputs.comment }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ScreenShotTest.yml
+++ b/.github/workflows/ScreenShotTest.yml
@@ -46,31 +46,32 @@ jobs:
           name: screenshot-test-results
           path: preview-screenshots/out/failures
 
-      - name: Checkout the docs branch
+      - name: New checkout for the companion branch
         id: checkout_docs
         if: ${{ hashFiles('preview-screenshots/out/failures/*.png') != '' }}
         uses: actions/checkout@v3
         with:
           path: temp_docs
-          ref: docs
 
       - name: Commit the screenshot to the branch
         id: docs_images
         if: steps.checkout_docs.outcome == 'success'
         continue-on-error: true # https://github.com/DroidKaigi/conference-app-2022/issues/497
+        env:
+          BRANCH_NAME: companion_${{ github.head_ref || github.ref_name }}
         run: |
-          cp -a preview-screenshots/out/failures/. temp_docs/docs/screenshots/
           cd temp_docs/
-          if ! git diff --exit-code --quiet
-          then
-            git add . --update
-            git commit -m "Upload screenshots to github page."
-            git push
-            sleep 3 # wait 3 minutes for github page to update
-          fi
+          git switch -C $BRANCH_NAME
+          mkdir -p docs/screenshots/
+          cp -a ../preview-screenshots/out/failures/. docs/screenshots/
+          git add .
+          git config --global push.default current
+          git config --global remote.pushDefault origin
+          git commit -m "Upload screenshots to github page."
+          git push -f
           cd ..
           cd preview-screenshots/out/failures
-          echo ::set-output name=images::$(ls | jq -R -s -c 'split("\n")[:-1]' | jq -r '.[] |= "https://droidkaigi.github.io/conference-app-2022/screenshots/" + .')
+          echo ::set-output name=images::$(ls | jq -R -s -c 'split("\n")[:-1]' | jq -r --arg IMAGE_PATH "https://raw.githubusercontent.com/droidkaigi/conference-app-2022/$BRANCH_NAME/docs/screenshots/" '.[] |= $IMAGE_PATH + .')
 
       - name: Build PR Comment with Preview
         id: pr_comment
@@ -80,7 +81,8 @@ jobs:
           ALL_SCREENSHOTS: ${{ steps.docs_images.outputs.images }}
         # Build a comment message with the image from snapshot images for demo purpose.
         run: |
-          echo "There are differences in Compose previews." > report.md
+          echo "There are differences in Compose previews:" > report.md
+          echo >> report.md # A blank line.
           echo "$ALL_SCREENSHOTS" | jq -r '.[]' | while read -r image; do 
             echo "![]($image)" >> report.md
           done

--- a/.github/workflows/ScreenShotTest.yml
+++ b/.github/workflows/ScreenShotTest.yml
@@ -63,7 +63,7 @@ jobs:
           cd temp_docs/
           git switch -C $BRANCH_NAME
           mkdir -p docs/screenshots/
-          cp -a ../preview-screenshots/out/failures/. docs/screenshots/
+          cp -a ../preview-screenshots/out/failures/delta* docs/screenshots/
           git add .
           git config --global push.default current
           git config --global remote.pushDefault origin

--- a/.github/workflows/ScreenShotTest.yml
+++ b/.github/workflows/ScreenShotTest.yml
@@ -71,7 +71,7 @@ jobs:
           git push -f
           cd ..
           cd preview-screenshots/out/failures
-          echo ::set-output name=images::$(ls | jq -R -s -c 'split("\n")[:-1]' | jq -r --arg IMAGE_PATH "https://raw.githubusercontent.com/droidkaigi/conference-app-2022/$BRANCH_NAME/docs/screenshots/" '.[] |= $IMAGE_PATH + .')
+          echo ::set-output name=images::$(ls -d delta* | jq -R -s -c 'split("\n")[:-1]' | jq -r --arg IMAGE_PATH "https://raw.githubusercontent.com/droidkaigi/conference-app-2022/$BRANCH_NAME/docs/screenshots/" '.[] |= $IMAGE_PATH + .')
 
       - name: Build PR Comment with Preview
         id: pr_comment


### PR DESCRIPTION
## Issue
- close #354

## Overview (Required)
- With this PR, a failed screenshot test will automatically push a comment to the same PR with **ALL** failed screenshots.
- Idea of this PR:
  - Create a new branch called the "companion" branch. This branch is used to save the failed screenshots.
  - Failed screenshots are uploaded to that branch, the URLs will be used in the PR comment.
  - Note: for now the branch is not deleted automatically. Let's have a TODO for that 🙇 .

- Currently the comment includes all failed screenshot test. It can be quite big if the failed cases are big (see the demo below). We can setup further filtering rules next.

## Links
- Please see a demo here: https://github.com/eneim/conference-app-2022/pull/1#issuecomment-1253412406
