### PR TITLE
Implement in-app language picker

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(libs.androidXChromeCustomTabs)
     implementation(libs.androidxNavigationCompose)
     implementation(libs.androidxStartup)
+    implementation(libs.androidxAppCompat)
     implementation(libs.hiltNavigationCompose)
     implementation(libs.material3)
     implementation(libs.firebaseCommon)

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2022
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -12,7 +13,7 @@ import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()

--- a/core/model/src/commonMain/resources/MR/base/strings.xml
+++ b/core/model/src/commonMain/resources/MR/base/strings.xml
@@ -45,6 +45,10 @@
     <string name="setting_title">設定</string>
     <string name="setting_item_dark_mode">ダークモード</string>
     <string name="setting_item_language">言語設定</string>
+    <string name="setting_language_system">システムのデフォルト</string>
+    <string name="setting_language_english">English</string>
+    <string name="setting_language_japanese">日本語</string>
+    <string name="setting_language_simplified_chinese">简体中文</string>
     <string name="setting_dialog_confirm">OK</string>
 
     <!-- Sponsors -->

--- a/core/model/src/commonMain/resources/MR/base/strings.xml
+++ b/core/model/src/commonMain/resources/MR/base/strings.xml
@@ -45,6 +45,7 @@
     <string name="setting_title">設定</string>
     <string name="setting_item_dark_mode">ダークモード</string>
     <string name="setting_item_language">言語設定</string>
+    <string name="setting_dialog_confirm">OK</string>
 
     <!-- Sponsors -->
     <string name="sponsors_top_app_bar_title">スポンサー</string>

--- a/core/model/src/commonMain/resources/MR/en/strings.xml
+++ b/core/model/src/commonMain/resources/MR/en/strings.xml
@@ -46,6 +46,9 @@
     <string name="setting_item_dark_mode">Dark Mode</string>
     <string name="setting_item_language">Language</string>
     <string name="setting_language_system">System Default</string>
+    <string name="setting_language_english" translatable="false">English</string>
+    <string name="setting_language_japanese" translatable="false">日本語</string>
+    <string name="setting_language_simplified_chinese" translatable="false">简体中文</string>
     <string name="setting_dialog_confirm">OK</string>
 
     <!-- Sponsors -->

--- a/core/model/src/commonMain/resources/MR/en/strings.xml
+++ b/core/model/src/commonMain/resources/MR/en/strings.xml
@@ -45,6 +45,7 @@
     <string name="setting_title">Setting</string>
     <string name="setting_item_dark_mode">Dark Mode</string>
     <string name="setting_item_language">Language</string>
+    <string name="setting_dialog_confirm">OK</string>
 
     <!-- Sponsors -->
     <string name="sponsors_top_app_bar_title">Sponsors</string>

--- a/core/model/src/commonMain/resources/MR/en/strings.xml
+++ b/core/model/src/commonMain/resources/MR/en/strings.xml
@@ -45,6 +45,7 @@
     <string name="setting_title">Setting</string>
     <string name="setting_item_dark_mode">Dark Mode</string>
     <string name="setting_item_language">Language</string>
+    <string name="setting_language_system">System Default</string>
     <string name="setting_dialog_confirm">OK</string>
 
     <!-- Sponsors -->

--- a/core/model/src/commonMain/resources/MR/zh/strings.xml
+++ b/core/model/src/commonMain/resources/MR/zh/strings.xml
@@ -47,6 +47,7 @@
     <string name="setting_title">设置</string>
     <string name="setting_item_dark_mode">深色模式</string>
     <string name="setting_item_language">语言设置</string>
+    <string name="setting_language_system">系统默认设置</string>
     <!-- TODO:Translation into Chinese -->
     <string name="setting_dialog_confirm">OK</string>
 

--- a/core/model/src/commonMain/resources/MR/zh/strings.xml
+++ b/core/model/src/commonMain/resources/MR/zh/strings.xml
@@ -48,6 +48,9 @@
     <string name="setting_item_dark_mode">深色模式</string>
     <string name="setting_item_language">语言设置</string>
     <string name="setting_language_system">系统默认设置</string>
+    <string name="setting_language_english" translatable="false">English</string>
+    <string name="setting_language_japanese" translatable="false">日本語</string>
+    <string name="setting_language_simplified_chinese" translatable="false">简体中文</string>
     <!-- TODO:Translation into Chinese -->
     <string name="setting_dialog_confirm">OK</string>
 

--- a/core/model/src/commonMain/resources/MR/zh/strings.xml
+++ b/core/model/src/commonMain/resources/MR/zh/strings.xml
@@ -47,6 +47,8 @@
     <string name="setting_title">设置</string>
     <string name="setting_item_dark_mode">深色模式</string>
     <string name="setting_item_language">语言设置</string>
+    <!-- TODO:Translation into Chinese -->
+    <string name="setting_dialog_confirm">OK</string>
 
     <!-- Sponsors -->
     <string name="sponsors_top_app_bar_title">赞助者</string>

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.kermit)
     implementation(libs.hiltNavigationCompose)
     implementation(libs.androidxCoreKtx)
+    implementation(libs.androidxAppCompat)
     implementation(libs.composeUi)
     implementation(libs.composeMaterial3)
     implementation(libs.composeMaterialIcons)

--- a/feature/setting/src/main/AndroidManifest.xml
+++ b/feature/setting/src/main/AndroidManifest.xml
@@ -1,2 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest></manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
+    </application>
+</manifest>

--- a/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
+++ b/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
@@ -11,13 +11,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -73,35 +71,8 @@ fun Setting(
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.Start
         ) {
-            DarkModeSetting()
             LanguageSetting()
         }
-    }
-}
-
-@Composable
-fun DarkModeSetting(
-    modifier: Modifier = Modifier
-) {
-    val checkedState = remember { mutableStateOf(true) }
-    Row(
-        modifier = modifier
-            .padding(vertical = 8.dp)
-            .fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(imageVector = Icons.Default.DarkMode, contentDescription = null)
-            Spacer(modifier = modifier.width(28.dp))
-            Text(text = stringResource(resource = Strings.setting_item_dark_mode))
-        }
-        Switch(
-            checked = checkedState.value,
-            onCheckedChange = { checkedState.value = it }
-        )
     }
 }
 

--- a/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
+++ b/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
+import dev.icerock.moko.resources.StringResource
 import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
@@ -177,7 +178,7 @@ private fun LanguageSelector(
                     selected = it.selected(currentLocale),
                     onClick = { onLocaleSelected(LocaleListCompat.forLanguageTags(it.tag)) }
                 )
-                Text(text = it.title)
+                Text(text = stringResource(resource = it.titleStringRes))
             }
         }
     }
@@ -201,12 +202,12 @@ private fun LanguageSettingPreview() {
 
 internal enum class LanguageItems(
     val tag: String,
-    val title: String
+    val titleStringRes: StringResource
 ) {
-    SYSTEM_DEFAULT("", "System Default"),
-    ENGLISH("en", "English"),
-    JAPANESE("ja", "日本語"),
-    SIMPLIFIED_CHINESE("zh-CN", "简体中文")
+    SYSTEM_DEFAULT("", Strings.setting_language_system),
+    ENGLISH("en", Strings.setting_language_english),
+    JAPANESE("ja", Strings.setting_language_japanese),
+    SIMPLIFIED_CHINESE("zh-CN", Strings.setting_language_simplified_chinese)
 }
 private fun LanguageItems.selected(it: LocaleListCompat): Boolean = when (this) {
     SYSTEM_DEFAULT -> it.isEmpty

--- a/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
+++ b/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
@@ -80,10 +80,12 @@ fun Setting(
 }
 
 @Composable
-fun DarkModeSetting() {
+fun DarkModeSetting(
+    modifier: Modifier = Modifier
+) {
     val checkedState = remember { mutableStateOf(true) }
     Row(
-        modifier = Modifier
+        modifier = modifier
             .padding(vertical = 8.dp)
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -93,7 +95,7 @@ fun DarkModeSetting() {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(imageVector = Icons.Default.DarkMode, contentDescription = null)
-            Spacer(modifier = Modifier.width(28.dp))
+            Spacer(modifier = modifier.width(28.dp))
             Text(text = stringResource(resource = Strings.setting_item_dark_mode))
         }
         Switch(
@@ -104,11 +106,13 @@ fun DarkModeSetting() {
 }
 
 @Composable
-private fun LanguageSetting() {
+private fun LanguageSetting(
+    modifier: Modifier = Modifier
+) {
     val openDialog = remember { mutableStateOf(false) }
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .padding(vertical = 8.dp)
             .fillMaxWidth()
             .clickable { openDialog.value = true },
@@ -119,7 +123,7 @@ private fun LanguageSetting() {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(imageVector = Icons.Default.Language, contentDescription = null)
-            Spacer(modifier = Modifier.width(28.dp))
+            Spacer(modifier = modifier.width(28.dp))
             Text(text = stringResource(resource = Strings.setting_item_language))
         }
     }
@@ -136,10 +140,10 @@ private fun LanguageSettingDialog(onClickConfirm: () -> Unit) {
         onDismissRequest = onClickConfirm,
         title = { Text(text = stringResource(resource = Strings.setting_item_language)) },
         text = {
-               LanguageSelector(
-                   currentLocale = selectedLocale,
-                   onLocaleSelected = onLocaleSelected
-               )
+            LanguageSelector(
+                currentLocale = selectedLocale,
+                onLocaleSelected = onLocaleSelected
+            )
         },
         confirmButton = {
             Button(
@@ -209,6 +213,7 @@ internal enum class LanguageItems(
     JAPANESE("ja", Strings.setting_language_japanese),
     SIMPLIFIED_CHINESE("zh-CN", Strings.setting_language_simplified_chinese)
 }
+
 private fun LanguageItems.selected(it: LocaleListCompat): Boolean = when (this) {
     SYSTEM_DEFAULT -> it.isEmpty
     else -> it.toLanguageTags().contains(tag)

--- a/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
+++ b/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2022.feature.setting
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,10 +8,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,11 +24,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.icerock.moko.resources.StringResource
 import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
+import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2022.strings.Strings
 
 @Composable
@@ -64,30 +71,17 @@ fun Setting(
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.Start
         ) {
-            SettingItem.values().forEach { item ->
-                SettingItem(
-                    icon = item.icon,
-                    title = stringResource(item.titleStringRes)
-                )
-            }
+            DarkModeSetting()
+            LanguageSetting()
         }
     }
 }
 
-enum class SettingItem(val titleStringRes: StringResource, val icon: ImageVector) {
-    DarkMode(Strings.setting_item_dark_mode, Icons.Default.DarkMode),
-    Language(Strings.setting_item_language, Icons.Default.Language)
-}
-
 @Composable
-fun SettingItem(
-    icon: ImageVector,
-    title: String,
-    modifier: Modifier = Modifier,
-) {
+fun DarkModeSetting() {
     val checkedState = remember { mutableStateOf(true) }
     Row(
-        modifier = modifier
+        modifier = Modifier
             .padding(vertical = 8.dp)
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -96,13 +90,106 @@ fun SettingItem(
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(imageVector = icon, contentDescription = null)
+            Icon(imageVector = Icons.Default.DarkMode, contentDescription = null)
             Spacer(modifier = Modifier.width(28.dp))
-            Text(text = title)
+            Text(text = stringResource(resource = Strings.setting_item_dark_mode))
         }
         Switch(
             checked = checkedState.value,
             onCheckedChange = { checkedState.value = it }
         )
     }
+}
+
+@Composable
+private fun LanguageSetting() {
+    val openDialog = remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .fillMaxWidth()
+            .clickable { openDialog.value = true },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(imageVector = Icons.Default.Language, contentDescription = null)
+            Spacer(modifier = Modifier.width(28.dp))
+            Text(text = stringResource(resource = Strings.setting_item_language))
+        }
+    }
+    if (openDialog.value) {
+        LanguageSettingDialog { openDialog.value = false }
+    }
+}
+
+@Composable
+private fun LanguageSettingDialog(onClickConfirm: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onClickConfirm,
+        title = { Text(text = stringResource(resource = Strings.setting_item_language)) },
+        text = { LanguageSelector() },
+        confirmButton = {
+            Button(onClick = onClickConfirm) {
+                Text(text = stringResource(resource = Strings.setting_dialog_confirm))
+            }
+        }
+    )
+}
+
+@Composable
+fun LanguageSelector() {
+    val languages = LanguageItems.values().toList()
+    val tags = remember { mutableStateOf("zh-CN") }
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        languages.forEach {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .selectable(
+                        selected = tags.value.contains(it.tag),
+                        onClick = {
+                            tags.value = it.tag
+                        }
+                    ),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = tags.value.contains(it.tag),
+                    onClick = {
+                        tags.value = it.tag
+                    }
+                )
+                Text(text = it.title)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SettingPreview() {
+    KaigiTheme {
+        SettingScreenRoot()
+    }
+}
+
+@Preview
+@Composable
+private fun LanguageSettingPreview() {
+    KaigiTheme {
+        LanguageSettingDialog {}
+    }
+}
+
+enum class LanguageItems(val tag: String, val title: String) {
+    SIMPLIFIED_CHINESE("zh-CN", "简体中文"),
+    ENGLISH("en", "English"),
+    JAPANESE("ja", "日本語"),
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ molecule = "0.4.0"
 buildkonfig = "0.13.3"
 
 androidxCore = "1.9.0"
+androidxAppCompat = "1.6.0-rc01"
 androidDesugarJdkLibs = "2.0.0"
 compose = "1.3.0-beta03"
 composeCompiler = "1.3.1"
@@ -90,6 +91,7 @@ accompanistFlowlayout = { module = "com.google.accompanist:accompanist-flowlayou
 kotlinSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 androidxCoreKtx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidxAppCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppCompat"}
 androidxNavigationCompose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigationCompose" }
 androidxLifecycleLifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidxActivityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }


### PR DESCRIPTION
## Issue
- close #385 

## Overview (Required)
- [x] Implement in-app language picker
- [x] Use AppCompat library to retrieve/update app's locale
- [x] Add support for devices running Android 12 and lower

## Links
- https://developer.android.com/guide/topics/resources/app-languages#api-implementation
- https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setApplicationLocales(androidx.core.os.LocaleListCompat)

## Screenshot
Android 13 (Pixel 4a) | Android 11 (Pixel 3)
:--: | :--:
<video src="https://user-images.githubusercontent.com/7891554/191778476-1349bea1-2019-4af6-b3e2-083d5e678fb9.mp4" width="300" /> | <video src="https://user-images.githubusercontent.com/7891554/191778450-cc7ee21d-e96d-4bdd-9f5f-f94bdf3bb55f.mp4" width="300" />








