### PR TITLE
Apply detekt designsystem

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("droidkaigi.convention.kmp")
     id("droidkaigi.primitive.android.compose")
+    id("droidkaigi.primitive.detekt")
 }
 
 android.namespace = "io.github.droidkaigi.confsched2022.core.designsystem"

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -8,13 +8,6 @@ android.namespace = "io.github.droidkaigi.confsched2022.core.designsystem"
 
 kotlin {
     explicitApiWarning()
-
-    sourceSets {
-        val commonMain by getting {
-        }
-        val androidMain by getting {
-        }
-    }
 }
 
 dependencies {

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiScaffold.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiScaffold.kt
@@ -11,8 +11,8 @@ import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KaigiScaffold(
-    modifier: Modifier = Modifier,
     topBar: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
     bottomBar: @Composable () -> Unit = {},
     content: @Composable (PaddingValues) -> Unit,
 ) {

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiTopAppBar.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiTopAppBar.kt
@@ -77,7 +77,7 @@ private fun KaigiTopAppBarPreview() = KaigiTopAppBar(
 
 @Preview
 @Composable
-private fun KaigiTopAppBarPreview_HiddenNavigationIcon() = KaigiTopAppBar(
+private fun KaigiTopAppBarPreviewHiddenNavigationIcon() = KaigiTopAppBar(
     showNavigationIcon = false,
     onNavigationIconClick = {},
     title = {

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiTopAppBar.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/KaigiTopAppBar.kt
@@ -27,9 +27,9 @@ import androidx.compose.ui.unit.dp
 fun KaigiTopAppBar(
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    title: (@Composable RowScope.() -> Unit),
     modifier: Modifier = Modifier,
     elevation: Dp = 2.dp,
-    title: (@Composable RowScope.() -> Unit),
     trailingIcons: (@Composable RowScope.() -> Unit)? = null,
 ) {
     TopAppBar(

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
@@ -23,10 +23,11 @@ fun UsernameRow(
     username: String,
     profileUrl: String?,
     iconUrl: String,
-    onLinkClick: (url: String, packageName: String?) -> Unit
+    onLinkClick: (url: String, packageName: String?) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clickable {
                 profileUrl?.let { url ->


### PR DESCRIPTION
## Issue
- close #565 

## Overview (Required)
- add the plugin `droidkaigi.primitive.detekt` and fix the lint errors by ./gradlew composeLint.


## Links
- The errors before fix.
[detekt report.pdf](https://github.com/DroidKaigi/conference-app-2022/files/9600516/detekt.report.pdf)

