### PR TITLE
Implement message by the session

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
@@ -89,7 +89,7 @@ fun SessionListItem(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Info,
-                            contentDescription = "information",
+                            contentDescription = "message by the session",
                             modifier = Modifier.size(16.dp),
                             tint = infoColor
                         )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionListItem.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -31,6 +33,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTag
+import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiColors.errorKeyColor80
 import io.github.droidkaigi.confsched2022.designsystem.theme.TimetableItemColor
 import io.github.droidkaigi.confsched2022.feature.sessions.R.drawable
 import io.github.droidkaigi.confsched2022.model.Lang
@@ -74,8 +77,32 @@ fun SessionListItem(
                     maxTitleLines = maxTitleLines,
                 )
             }
-            Spacer(modifier = Modifier.height(8.dp))
+
             if (timetableItem is Session) {
+                val message = timetableItem.message
+                if (message != null) {
+                    val infoColor = Color(errorKeyColor80)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Info,
+                            contentDescription = "information",
+                            modifier = Modifier.size(16.dp),
+                            tint = infoColor
+                        )
+                        Text(
+                            text = message.currentLangTitle,
+                            color = infoColor,
+                            style = MaterialTheme.typography.labelMedium
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -97,8 +124,10 @@ fun SessionListItem(
                         style = MaterialTheme.typography.labelMedium,
                     )
                 }
-                Spacer(modifier = Modifier.height(8.dp))
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTag
-import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiColors
 import io.github.droidkaigi.confsched2022.designsystem.theme.TimetableItemColor
 import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.TimetableItem.Session
@@ -62,7 +61,7 @@ fun TimetableItem(
                     imageVector = Icons.Default.Info,
                     contentDescription = "message by the session",
                     modifier = Modifier.size(16.dp),
-                    tint = Color(KaigiColors.errorKeyColor80)
+                    tint = Color.White
                 )
             }
             Text(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -60,7 +60,7 @@ fun TimetableItem(
             if (timetableItem is Session && timetableItem.message != null) {
                 Icon(
                     imageVector = Icons.Default.Info,
-                    contentDescription = "information",
+                    contentDescription = "message by the session",
                     modifier = Modifier.size(16.dp),
                     tint = Color(KaigiColors.errorKeyColor80)
                 )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -5,6 +5,10 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,8 +24,10 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTag
+import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiColors
 import io.github.droidkaigi.confsched2022.designsystem.theme.TimetableItemColor
 import io.github.droidkaigi.confsched2022.model.TimetableItem
+import io.github.droidkaigi.confsched2022.model.TimetableItem.Session
 
 @Composable
 fun TimetableItem(
@@ -51,6 +57,14 @@ fun TimetableItem(
                 .semantics { contentDescription = "isFavorited$isFavorited" }
                 .testTag("favorite")
         ) {
+            if (timetableItem is Session && timetableItem.message != null) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = "information",
+                    modifier = Modifier.size(16.dp),
+                    tint = Color(KaigiColors.errorKeyColor80)
+                )
+            }
             Text(
                 text = timetableItem.title.currentLangTitle,
                 color = Color.White,


### PR DESCRIPTION
## Issue
- close #539

## Overview (Required)
- Add information icon and message by the session in TimetableItem. 
- Add information icon in SessionListItem. 

## Links
- [Figma](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=20%3A570)

## Screenshot
The image displayed with temporary data inserted. 
### Timetable
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/34018372/191068949-f0efce06-d1f1-49d9-982a-f519c368a0d6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/34018372/191071679-881d39fe-9eb5-43c6-94ea-efd313510561.png" width="300" />

## Session
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/34018372/191069026-fe7a0e6a-a68b-4a42-8461-c6713d4c1d6e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/34018372/191068615-04fd3b92-0667-45fd-9cda-06ac8a5ec251.png" width="300" />