### PR TITLE
Update: limit text size in timetable

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -42,8 +42,11 @@ fun TimetableItem(
     } else {
         Color(roomColor).copy(alpha = 0.2F)
     }
+    val titleTextStyle = MaterialTheme.typography.titleMedium
     val localDensity = LocalDensity.current.let {
-        Density(it.density * verticalScale, it.fontScale)
+        check(titleTextStyle.fontSize.isSp)
+        val densityScale = maxOf(verticalScale, 8f / titleTextStyle.fontSize.value)
+        Density(it.density * densityScale, it.fontScale)
     }
     CompositionLocalProvider(
         LocalDensity provides localDensity,
@@ -72,7 +75,7 @@ fun TimetableItem(
                     .weight(weight = 1f, fill = false)
                     .fillMaxWidth(),
                 overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.titleMedium.copy(
+                style = titleTextStyle.copy(
                     letterSpacing = 0.1.sp
                 )
             )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimetableItem.kt
@@ -45,6 +45,7 @@ fun TimetableItem(
     val titleTextStyle = MaterialTheme.typography.titleMedium
     val localDensity = LocalDensity.current.let {
         check(titleTextStyle.fontSize.isSp)
+        // Limit the size to no more than 8sp or less
         val densityScale = maxOf(verticalScale, 8f / titleTextStyle.fontSize.value)
         Density(it.density * densityScale, it.fontScale)
     }


### PR DESCRIPTION
## Issue
- close #344 

## Overview (Required)
- set a minimum value for the density of TimetableItem
  - calculated so that the text size of a title is at least 8 sp
  - if we use 12 sp, the layout of short items (less than 40 min) will be broken (in Pixel 6)
    - more layouts will be broken on smaller devices, but I think it would be difficult to deal with by changing the minimum text size

## Links
- 

## Screenshot
device: Pixel 6

Description | Before | After
:--: | :--: | :--:
font size: min | <img src=https://user-images.githubusercontent.com/23146955/191430412-122e5963-64fe-4312-b82d-47a542c4bfcf.png  width="300"> | <img src=https://user-images.githubusercontent.com/23146955/191430505-c965a016-cb4e-41d0-8d6c-24e30cca74fe.png  width="300">
font size: max | <img src=https://user-images.githubusercontent.com/23146955/191430628-ba7d945c-93a4-41ce-95d5-a58390423913.png  width="300"> | <img src=https://user-images.githubusercontent.com/23146955/191430663-4f7beb77-7c28-4ca7-b546-50dd9af053c6.png  width="300">

ref. if we calculate so that the text size of a title is at least 12 sp
Description | Before | After (12 sp)
:--: | :--: | :--:
font size: min | <img src=https://user-images.githubusercontent.com/23146955/191430412-122e5963-64fe-4312-b82d-47a542c4bfcf.png  width="300"> | <img src=https://user-images.githubusercontent.com/23146955/191431777-55df3df4-5011-4981-967b-22ff2a8b5e8b.png  width="300">
font size: max | <img src=https://user-images.githubusercontent.com/23146955/191430628-ba7d945c-93a4-41ce-95d5-a58390423913.png  width="300"> | <img src=https://user-images.githubusercontent.com/23146955/191431821-befaa224-f49a-45d0-9b16-ca9f667a52f9.png  width="300">
