### PR TITLE
Fix stickyHeader of AnnouncementContentList

### DIFF
--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -112,28 +112,33 @@ fun AnnouncementContentList(
     innerPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier = Modifier.padding(horizontal = 16.dp),
-        contentPadding = innerPadding,
+    Box(
+        modifier = Modifier.padding(innerPadding)
     ) {
-        announcements.forEach {
-            // TODO: Need to fix stickyHeader to make it work.
-            stickyHeader {
-                AnnouncementsHeader(dayString = it.publishedAt.convertString())
-            }
-            itemsIndexed(it.announcements) { index, announcement ->
-                AnnouncementContent(
-                    type = AnnouncementType.valueOf(announcement.type),
-                    title = announcement.title,
-                    content = announcement.content
-                )
-                if (index >= announcements.lastIndex) {
-                    Divider(
-                        modifier = modifier
-                            .padding(start = 16.dp, end = 16.dp),
-                        thickness = 1.dp,
-                        color = Color(KaigiColors.neutralVariantKeyColor60)
+        LazyColumn(
+            modifier = Modifier.padding(horizontal = 16.dp),
+        ) {
+            announcements.forEach {
+                // TODO: Need to fix stickyHeader to make it work.
+                stickyHeader {
+                    AnnouncementsHeader(
+                        dayString = it.publishedAt.convertString()
                     )
+                }
+                itemsIndexed(it.announcements) { index, announcement ->
+                    AnnouncementContent(
+                        type = AnnouncementType.valueOf(announcement.type),
+                        title = announcement.title,
+                        content = announcement.content
+                    )
+                    if (index >= announcements.lastIndex) {
+                        Divider(
+                            modifier = modifier
+                                .padding(start = 16.dp, end = 16.dp),
+                            thickness = 1.dp,
+                            color = Color(KaigiColors.neutralVariantKeyColor60)
+                        )
+                    }
                 }
             }
         }

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -119,7 +119,6 @@ fun AnnouncementContentList(
             modifier = Modifier.padding(horizontal = 16.dp),
         ) {
             announcements.forEach {
-                // TODO: Need to fix stickyHeader to make it work.
                 stickyHeader {
                     AnnouncementsHeader(
                         dayString = it.publishedAt.convertString()


### PR DESCRIPTION
## Issue
- close #649

## Overview (Required)
- Fix stickyHeader of AnnouncementContentList.
- It seems that the cause of the problem was that the header was hidden under the topbar.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<video src="https://user-images.githubusercontent.com/5406001/191549634-482e55d1-01ac-47a1-baee-a758bdc9e5b2.mp4">|<video src="https://user-images.githubusercontent.com/5406001/191549884-7b0976ac-4cfe-4033-a081-2c1375d6c860.mp4"> 


