### PR TITLE
[iOS] Open map url from AboutPage

### DIFF
--- a/app-ios/Sources/AboutFeature/AboutView.swift
+++ b/app-ios/Sources/AboutFeature/AboutView.swift
@@ -1,13 +1,13 @@
 import appioscombined
 import ComposableArchitecture
 import LicenseList
+import SafariView
 import StaffFeature
 import SwiftUI
 import Theme
 
 public enum AboutDestination {
     case none
-    case access
     case staffs
     case privacyPolicy
     case license
@@ -37,6 +37,7 @@ public enum AboutAction {
 }
 
 public struct AboutEnvironment {
+    @Environment(\.openURL) var openURL
     public init() {}
 }
 
@@ -46,7 +47,7 @@ public let aboutReducer = Reducer<AboutState, AboutAction, AboutEnvironment>.com
         action: /AboutAction.staff,
         environment: { _ in .init() }
     ),
-    .init { state, action, _ in
+    .init { state, action, environment in
         switch action {
         case .backToTop:
             state.navigationDestination = .none
@@ -58,7 +59,7 @@ public let aboutReducer = Reducer<AboutState, AboutAction, AboutEnvironment>.com
             state.navigationDestination = .staffs
             return .none
         case .openAccess:
-            state.navigationDestination = .access
+            environment.openURL(URL(string: StaticURLs.access)!)
             return .none
         case .openPrivacyPolicy:
             state.navigationDestination = .privacyPolicy
@@ -155,8 +156,6 @@ public struct AboutView: View {
                                 StaffView(
                                     store: store.scope(state: \.staffState, action: AboutAction.staff)
                                 )
-                            case .access:
-                                Text("TODO: Access")
                             case .privacyPolicy:
                                 Text("TODO: Privacy Policy")
                             case .license:

--- a/app-ios/Sources/AboutFeature/AboutView.swift
+++ b/app-ios/Sources/AboutFeature/AboutView.swift
@@ -140,7 +140,7 @@ public struct AboutView: View {
 
                     Spacer()
                         .frame(height: 32)
-                    
+
                     NavigationLink(isActive: Binding<Bool>(
                         get: {
                             viewStore.navigationDestination != .none

--- a/app-ios/Sources/AboutFeature/AboutView.swift
+++ b/app-ios/Sources/AboutFeature/AboutView.swift
@@ -1,7 +1,6 @@
 import appioscombined
 import ComposableArchitecture
 import LicenseList
-import SafariView
 import StaffFeature
 import SwiftUI
 import Theme

--- a/app-ios/Sources/AboutFeature/StaticURLs.swift
+++ b/app-ios/Sources/AboutFeature/StaticURLs.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public struct StaticURLs {
+    public static let access: String = "https://goo.gl/maps/NnqJr2zUVdrAJseH7"
     public static let twitter: String = "https://twitter.com/DroidKaigi"
     public static let youtube: String = "https://www.youtube.com/c/DroidKaigi"
     public static let medium: String = "https://medium.com/droidkaigi"


### PR DESCRIPTION
## Issue
- close #557

## Overview (Required)
- 26750186aa8187be46b649b9806dba8b5f7278ac
    - open map url in Safari.app with using `@Environment(\.openURL) var openURL`
- 042cc400972ece25b9fc268b04b77c65ddc1a928
    - fix SwiftLint warning

## Links
- N/A

## Screenshot

<img src="https://user-images.githubusercontent.com/737116/191665250-f8f7500f-41b2-4bd2-9833-a0fd27aeb32d.gif" width="300" />

