### PR TITLE
Close bottom sheet when click search text field

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -153,6 +155,9 @@ fun SearchRoot(
                 viewModel.onFilterFavoritesToggle()
             },
             onBackIconClick = onBackIconClick,
+            onSearchTextAreaClicked = {
+                viewModel.onSearchTextAreaClicked()
+            }
         )
     }
 }
@@ -165,6 +170,7 @@ private fun SearchScreen(
     onDayFilterClicked: () -> Unit,
     onCategoriesFilteredClicked: () -> Unit,
     onFavoritesToggleClicked: () -> Unit,
+    onSearchTextAreaClicked: () -> Unit,
     onBackIconClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -183,7 +189,8 @@ private fun SearchScreen(
                     is Success -> {
                         SearchTextField(
                             searchWord = searchWord.value,
-                            onSearchWordChange = { searchWord.value = it }
+                            onSearchWordChange = { searchWord.value = it },
+                            onSearchTextAreaClicked = onSearchTextAreaClicked,
                         ) {
                             onBackIconClick()
                         }
@@ -218,13 +225,23 @@ private fun SearchScreen(
 private fun SearchTextField(
     searchWord: String,
     onSearchWordChange: (String) -> Unit,
+    onSearchTextAreaClicked: () -> Unit,
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
+    val interactionSource = remember { MutableInteractionSource() }
+
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
+    }
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect {
+            if (it is PressInteraction.Release) {
+                onSearchTextAreaClicked()
+            }
+        }
     }
     TextField(
         value = searchWord,
@@ -256,6 +273,7 @@ private fun SearchTextField(
         onValueChange = {
             onSearchWordChange(it)
         },
+        interactionSource = interactionSource,
     )
 }
 
@@ -411,7 +429,8 @@ fun SearchScreenPreview() {
             onBackIconClick = {},
             onFavoritesToggleClicked = {},
             onDayFilterClicked = {},
-            onCategoriesFilteredClicked = {}
+            onCategoriesFilteredClicked = {},
+            onSearchTextAreaClicked = {},
         )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SearchViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SearchViewModel.kt
@@ -131,4 +131,8 @@ class SearchViewModel @Inject constructor(
     fun onFilterSheetDismissed() {
         filterSheetState.value = SearchFilterSheetState.Hide
     }
+
+    fun onSearchTextAreaClicked() {
+        onFilterSheetDismissed()
+    }
 }


### PR DESCRIPTION
## Issue
- close #675 

## Overview (Required)
- can closed bottom sheet when the SearchTextField clicked.
- I used interactionSource to achieve click detection. Because `clickable` doesn't work.

## Links
- https://stackoverflow.com/questions/67902919/jetpack-compose-textfield-clickable-does-not-work
- https://developer.android.com/reference/kotlin/androidx/compose/foundation/interaction/InteractionSource

## Screenshot

### Before
https://user-images.githubusercontent.com/46647326/191802544-cfcd5204-0131-467b-ad7b-231c8711f43b.mp4

### After
https://user-images.githubusercontent.com/46647326/191802790-21c7c24c-c1d0-4350-9044-99e8331fc0f0.mp4
