### PR TITLE
add: Github Actions: Delete old branch saving screenshots

### DIFF
--- a/.github/workflows/ScreenShotTest.yml
+++ b/.github/workflows/ScreenShotTest.yml
@@ -94,3 +94,22 @@ jobs:
         with:
           message: ${{ steps.pr_comment.outputs.comment }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete old branch saving screenshots
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPIRED_TERM: 2w # first letter of year, month, week and day
+          REMOTE_REPO: origin
+          TARGET_BRANCH_PREFIX: companion_
+          DATE_FORMAT: '%Y%m%d'
+        run: |
+          expired_date=`date -v-$EXPIRED_TERM "+${DATE_FORMAT}"` 
+          git fetch --all
+          git branch -r | grep "[^* ]+" -Eo | grep "${REMOTE_REPO}/${TARGET_BRANCH_PREFIX}.+" -Eo |
+          while read branch; do
+            commit_date=`git show -s $branch --format='%cd' --date=format:"${DATE_FORMAT}"`
+            if [[ $commit_date -le $expired_date ]]; then
+              short_branch=`echo $branch | sed "s/${REMOTE_REPO}\///g"`
+              git push ${REMOTE_REPO} --delete $short_branch
+            fi 
+          done


### PR DESCRIPTION
## Issue
- close #650 

## Overview (Required)
- Added delete script at the end of ScreenShotTest action.
- 2 weeks expired term can be changed at env parameter if some other term is preferred.
- I am not sure if it works correctly but I just confirmed on my own repository..!

Thank you for the review !

