### PR TITLE
Improved clear input button touch target size

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.BottomSheetScaffold
 import androidx.compose.material.BottomSheetValue
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.IconButton
 import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -245,13 +246,14 @@ private fun SearchTextField(
             )
         },
         trailingIcon = {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_delete),
-                contentDescription = "search_word_delete_icon",
-                modifier = Modifier.clickable {
-                    onSearchWordChange("")
-                }
-            )
+            IconButton(
+                onClick = { onSearchWordChange("") }
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_delete),
+                    contentDescription = "search_word_delete_icon",
+                )
+            }
         },
         onValueChange = {
             onSearchWordChange(it)


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Applied `IconButton` to improve target size and ripple area of input field clear button.


## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13705006/191878669-6611b33b-6871-4661-8dbc-11421bbe40dd.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13705006/191878667-f55c1dc4-1630-4e0b-ac38-20f09e792a55.png" width="300" /> 

