### PR TITLE
Activate RememberMissing rule for detekt

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -46,7 +46,7 @@ TwitterCompose:
   PreviewPublic:
     active: true
   RememberMissing:
-    active: false
+    active: true
   ViewModelForwarding:
     active: true
   ViewModelInjection:


### PR DESCRIPTION
## Issue
- close #520

## Overview (Required)

- Activate RememberMissing rule for detekt.
- I ran `./gradlew composeLint`, but there is no need to fix anything.

