### PR TITLE
[iOS] fix SwiftLint warnings

### DIFF
--- a/app-ios/Sources/AboutFeature/Content/LicenseView.swift
+++ b/app-ios/Sources/AboutFeature/Content/LicenseView.swift
@@ -1,6 +1,6 @@
 import appioscombined
-import Model
 import LicenseList
+import Model
 import SwiftUI
 
 struct AboutLicenseView: View {

--- a/app-ios/Sources/AppFeature/AppView.swift
+++ b/app-ios/Sources/AppFeature/AppView.swift
@@ -1,5 +1,6 @@
-import appioscombined
+// swiftlint:disable file_length
 import AboutFeature
+import appioscombined
 import Assets
 import Auth
 import ComposableArchitecture


### PR DESCRIPTION
## Issue
- unissued

## Overview (Required)
- I found a few SwiftLint warnings and fixed them.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
