### PR TITLE
[iOS] Fix layout constraint warnings in the map view

### DIFF
--- a/app-ios/Sources/MapFeature/MapView.swift
+++ b/app-ios/Sources/MapFeature/MapView.swift
@@ -53,6 +53,7 @@ public struct MapView: View {
                     }
                 }
             }
+            .navigationViewStyle(.stack)
         }
     }
 }


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR fixes the following layout constraint warnings in the map view:

```
2022-09-23 16:59:27.287210+0900 DroidKaigi2022[50149:8290017] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600001ff4280 'BIB_Leading_Leading' H:|-(0)-[_UIModernBarButton:0x7f92890a0890]   (active, names: '|':_UIButtonBarButton:0x7f9289098120 )>",
    "<NSLayoutConstraint:0x600001ff5040 'UINav_static_button_horiz_position' _UIModernBarButton:0x7f92890a0890.leading == UILayoutGuide:0x6000005772c0'UIViewLayoutMarginsGuide'.leading   (active)>",
    "<NSLayoutConstraint:0x600001ff5090 'UINavItemContentGuide-leading' H:[_UIButtonBarButton:0x7f9289098120]-(6)-[UILayoutGuide:0x600000576d80'UINavigationBarItemContentLayoutGuide']   (active)>",
    "<NSLayoutConstraint:0x600001f0c140 'UINavItemContentGuide-trailing' UILayoutGuide:0x600000576d80'UINavigationBarItemContentLayoutGuide'.trailing == _UINavigationBarContentView:0x7f928909f340.trailing   (active)>",
    "<NSLayoutConstraint:0x600001ff6d00 'UIView-Encapsulated-Layout-Width' _UINavigationBarContentView:0x7f928909f340.width == 0   (active)>",
    "<NSLayoutConstraint:0x600001f0c820 'UIView-leftMargin-guide-constraint' H:|-(8)-[UILayoutGuide:0x6000005772c0'UIViewLayoutMarginsGuide'](LTR)   (active, names: '|':_UINavigationBarContentView:0x7f928909f340 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600001ff4280 'BIB_Leading_Leading' H:|-(0)-[_UIModernBarButton:0x7f92890a0890]   (active, names: '|':_UIButtonBarButton:0x7f9289098120 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2022-09-23 16:59:27.288346+0900 DroidKaigi2022[50149:8290017] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600001f0e080 UIView:0x7f92890a5350.trailing == _UIBackButtonMaskView:0x7f92890a3ae0.trailing   (active)>",
    "<NSLayoutConstraint:0x600001ff48c0 'Mask_Trailing_Trailing' _UIBackButtonMaskView:0x7f92890a3ae0.trailing == _UIButtonBarButton:0x7f9289098120.trailing   (active)>",
    "<NSLayoutConstraint:0x600001ff4a00 'MaskEV_Leading_BIB_Trailing' H:[_UIModernBarButton:0x7f92890a0890]-(0)-[UIView:0x7f92890a5350]   (active)>",
    "<NSLayoutConstraint:0x600001ff5040 'UINav_static_button_horiz_position' _UIModernBarButton:0x7f92890a0890.leading == UILayoutGuide:0x6000005772c0'UIViewLayoutMarginsGuide'.leading   (active)>",
    "<NSLayoutConstraint:0x600001ff5090 'UINavItemContentGuide-leading' H:[_UIButtonBarButton:0x7f9289098120]-(6)-[UILayoutGuide:0x600000576d80'UINavigationBarItemContentLayoutGuide']   (active)>",
    "<NSLayoutConstraint:0x600001f0c140 'UINavItemContentGuide-trailing' UILayoutGuide:0x600000576d80'UINavigationBarItemContentLayoutGuide'.trailing == _UINavigationBarContentView:0x7f928909f340.trailing   (active)>",
    "<NSLayoutConstraint:0x600001ff6d00 'UIView-Encapsulated-Layout-Width' _UINavigationBarContentView:0x7f928909f340.width == 0   (active)>",
    "<NSLayoutConstraint:0x600001f0c820 'UIView-leftMargin-guide-constraint' H:|-(8)-[UILayoutGuide:0x6000005772c0'UIViewLayoutMarginsGuide'](LTR)   (active, names: '|':_UINavigationBarContentView:0x7f928909f340 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600001f0e080 UIView:0x7f92890a5350.trailing == _UIBackButtonMaskView:0x7f92890a3ae0.trailing   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2022-09-23 16:59:27.295211+0900 DroidKaigi2022[50149:8290017] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600001ff42d0 'BIB_Trailing_CB_Leading' H:[_UIModernBarButton:0x7f92890a0890]-(6)-[_UIModernBarButton:0x7f92890995a0'\U30d5\U30ed\U30a2\U30de\U30c3\U30d7']   (active)>",
    "<NSLayoutConstraint:0x600001ff4320 'CB_Trailing_Trailing' _UIModernBarButton:0x7f92890995a0'\U30d5\U30ed\U30a2\U30de\U30c3\U30d7'.trailing <= _UIButtonBarButton:0x7f9289098120.trailing   (active)>",
    "<NSLayoutConstraint:0x600001ff5040 'UINav_static_button_horiz_position' _UIModernBarButton:0x7f92890a0890.leading == UILayoutGuide:0x6000005772c0'UIViewLayoutMarginsGuide'.leading   (active)>",
    "<NSLayoutConstraint:0x600001ff5090 'UINavItemContentGuide-leading' H:[_UIButtonBarButton:0x7f9289098120]-(6)-[UILayoutGuide:0x600000576d80'UINavigationBarItemContentLayoutGuide']   (active)>",
    "<NSLayoutConstraint:0x600001f0c140 'UINavItemContentGuide-trailing' UILayoutGuide:0x600000576d80'UINavigationBarItemContentLayoutGuide'.trailing == _UINavigationBarContentView:0x7f928909f340.trailing   (active)>",
    "<NSLayoutConstraint:0x600001ff6d00 'UIView-Encapsulated-Layout-Width' _UINavigationBarContentView:0x7f928909f340.width == 0   (active)>",
    "<NSLayoutConstraint:0x600001f0c820 'UIView-leftMargin-guide-constraint' H:|-(8)-[UILayoutGuide:0x6000005772c0'UIViewLayoutMarginsGuide'](LTR)   (active, names: '|':_UINavigationBarContentView:0x7f928909f340 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600001ff42d0 'BIB_Trailing_CB_Leading' H:[_UIModernBarButton:0x7f92890a0890]-(6)-[_UIModernBarButton:0x7f92890995a0'フロアマップ']   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
``` 

- I don't know why but specifying the navigation view style resolves them

## Links
- https://stackoverflow.com/questions/65316497

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
