### PR TITLE
Open floor map from session detail ▲

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -256,7 +256,9 @@ class KaigiAppScaffoldState @OptIn(ExperimentalMaterial3Api::class) constructor(
     }
 
     fun onNavigateFloorMapClick() {
-        TODO("Floor map is not yet implemented.")
+        navController.navigate(
+            route = MapNavGraph.mapRoute
+        )
     }
 
     fun onNavigationClick() {


### PR DESCRIPTION
## Issue
- close #485

## Overview (Required)
- When the ▲ on the session details screen is tapped, the transition to floor map screen is made.

## Links
- Nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/20397967/191930433-b914e6b5-56d8-4e60-a1f0-4c170203b592.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/20397967/191930377-811693a8-ebb2-4ee4-bbfa-3acef3ed69ed.gif" width="300" />
