### PR TITLE
Use map icon instead of ▲ in session detail.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -242,7 +242,7 @@ fun SessionDetailBottomAppBar(
                 }
                 IconButton(onClick = onNavigateFloorMapClick) {
                     Icon(
-                        painter = painterResource(id = R.drawable.ic_02),
+                        painter = painterResource(id = R.drawable.ic_map),
                         contentDescription = "go to floor map",
                     )
                 }

--- a/feature/sessions/src/main/res/drawable/ic_map.xml
+++ b/feature/sessions/src/main/res/drawable/ic_map.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20.5 3L20.34 3.03L15 5.1L9 3L3.36 4.9C3.15 4.97 3 5.15 3 5.38V20.5C3 20.78 3.22 21 3.5 21L3.66 20.97L9 18.9L15 21L20.64 19.1C20.85 19.03 21 18.85 21 18.62V3.5C21 3.22 20.78 3 20.5 3ZM15 19L9 16.89V5L15 7.11V19Z"
+      android:fillColor="#C0C9C1"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
## Issue
- close #710 

## Overview (Required)
- Use map icon instead of ▲ in session detail.

## Links
- https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/80536544/192068251-8703f6e1-3d6a-4f60-ac27-bbe547a0f668.png" width="300" /> | <img src="https://user-images.githubusercontent.com/80536544/192068260-13d55d16-006f-4ffa-884a-53a397bcc571.png" width="300" />
