### PR TITLE
Apply fab icon size in session detail.

### DIFF
--- a/feature/sessions/src/main/res/drawable/ic_bookmark.xml
+++ b/feature/sessions/src/main/res/drawable/ic_bookmark.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="18dp"
+    android:width="14dp"
     android:height="18dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportWidth="14"
+    android:viewportHeight="18">
     <path
         android:fillColor="#C0C9C1"
-        android:pathData="M17,3L7,3c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3L19,5c0,-1.1 -0.9,-2 -2,-2zM17,18l-5,-2.18L7,18L7,5h10v13z" />
+        android:pathData="M2 0H12C13.1 0 14 0.9 14 2V18L7 15L0 18V2C0 0.9 0.9 0 2 0ZM7 12.82L12 15V2H2V15L7 12.82Z" />
 </vector>

--- a/feature/sessions/src/main/res/drawable/ic_bookmark_filled.xml
+++ b/feature/sessions/src/main/res/drawable/ic_bookmark_filled.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="18dp"
+    android:width="14dp"
     android:height="18dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportWidth="14"
+    android:viewportHeight="18">
     <path
         android:fillColor="#C0C9C1"
-        android:pathData="M17,3H7c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3V5c0,-1.1 -0.9,-2 -2,-2z" />
+        android:pathData="M12 0H2C0.9 0 0 0.9 0 2V18L7 15L14 18V2C14 0.9 13.1 0 12 0Z" />
 </vector>


### PR DESCRIPTION
## Issue
- close #709 

## Overview (Required)
- Fix bookmark icon size in session detail.

## Links
- https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/80536544/192074315-2d02d30f-815e-4109-829c-7799b06fee81.png" width="300" /> | <img src="https://user-images.githubusercontent.com/80536544/192074336-a3dfcd69-351b-423c-8fc1-aa0c3724c13d.png" width="300" />
<img src="https://user-images.githubusercontent.com/80536544/192074438-dbdb7394-7d9d-4985-8142-2f3fcba46c60.png" width="300" /> | <img src="https://user-images.githubusercontent.com/80536544/192074445-6866f875-6678-4a2b-9888-494ef64b6cd0.png" width="300" />





