### PR TITLE
Introduce error handring to sessions

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/sessions/DataSessionsRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/sessions/DataSessionsRepository.kt
@@ -9,7 +9,6 @@ import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.launch
 
 public class DataSessionsRepository(
     private val sessionsApi: SessionsApi,
@@ -17,7 +16,6 @@ public class DataSessionsRepository(
     private val settingsDatastore: SettingsDatastore
 ) : SessionsRepository {
     override fun droidKaigiScheduleFlow(): Flow<DroidKaigiSchedule> = callbackFlow {
-        launch { refresh() }
         combine(
             sessionsDao.selectAll(),
             settingsDatastore.favoriteSessionIds(),
@@ -25,7 +23,7 @@ public class DataSessionsRepository(
         )
             .collect { (timetable, favoriteSessionIds) ->
                 val favorites = favoriteSessionIds.map { TimetableItemId(it) }.toPersistentSet()
-                trySend(
+                send(
                     DroidKaigiSchedule.of(timetable.copy(favorites = favorites))
                 )
             }

--- a/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/AppErrorSnackbarEffect.kt
+++ b/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/AppErrorSnackbarEffect.kt
@@ -13,7 +13,7 @@ import io.github.droidkaigi.confsched2022.strings.Strings
 public fun AppErrorSnackbarEffect(
     appError: AppError?,
     snackBarHostState: SnackbarHostState,
-    onRetryDismissed: () -> Unit,
+    onAppErrorNotified: () -> Unit,
     onRetryButtonClick: () -> Unit
 ) {
     val errorMessage = stringResource(Strings.error_common_message)
@@ -25,7 +25,7 @@ public fun AppErrorSnackbarEffect(
                 actionLabel = retryMessage,
                 duration = Long
             )
-            onRetryDismissed()
+            onAppErrorNotified()
             if (snackbarResult == ActionPerformed) onRetryButtonClick()
         }
     }

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -61,7 +61,7 @@ fun AnnouncementsScreenRoot(
         uiModel = uiModel,
         showNavigationIcon = showNavigationIcon,
         onRetryButtonClick = { viewModel.onRetryButtonClick() },
-        onRetryDismissed = { viewModel.onRetryShown() },
+        onAppErrorNotified = { viewModel.onAppErrorNotified() },
         onNavigationIconClick = onNavigationIconClick
     )
 }
@@ -71,7 +71,7 @@ fun Announcements(
     uiModel: AnnouncementsUiModel,
     showNavigationIcon: Boolean,
     onRetryButtonClick: () -> Unit,
-    onRetryDismissed: () -> Unit,
+    onAppErrorNotified: () -> Unit,
     modifier: Modifier = Modifier,
     onNavigationIconClick: () -> Unit,
 ) {
@@ -95,7 +95,7 @@ fun Announcements(
         AppErrorSnackbarEffect(
             appError = uiModel.appError,
             snackBarHostState = snackbarHostState,
-            onRetryDismissed = onRetryDismissed,
+            onAppErrorNotified = onAppErrorNotified,
             onRetryButtonClick = onRetryButtonClick
         )
         when (uiModel.state) {
@@ -266,7 +266,7 @@ fun AnnouncementsPreview() {
             ),
             showNavigationIcon = true,
             onRetryButtonClick = {},
-            onRetryDismissed = {},
+            onAppErrorNotified = {},
         ) {}
     }
 }

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementsViewModel.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/AnnouncementsViewModel.kt
@@ -60,7 +60,7 @@ class AnnouncementsViewModel @Inject constructor(
         }
     }
 
-    fun onRetryShown() {
+    fun onAppErrorNotified() {
         appError = null
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -65,6 +66,7 @@ import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day
 import io.github.droidkaigi.confsched2022.model.DroidKaigiSchedule
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
@@ -107,6 +109,8 @@ fun SessionsScreenRoot(
         onToggleTimetableClick = { isTimetable ->
             viewModel.onTimetableModeToggle(isTimetable)
         },
+        onRetryButtonClick = { viewModel.onRetryButtonClick() },
+        onAppErrorNotified = { viewModel.onAppErrorNotified() },
     )
 }
 
@@ -120,6 +124,8 @@ fun Sessions(
     onFavoriteClick: (TimetableItemId, Boolean) -> Unit,
     onSearchClick: () -> Unit,
     onToggleTimetableClick: (Boolean) -> Unit,
+    onRetryButtonClick: () -> Unit,
+    onAppErrorNotified: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scheduleState = uiModel.state
@@ -135,8 +141,10 @@ fun Sessions(
         timetableListStates,
         sessionsListListStates
     )
+    val snackbarHostState = remember { SnackbarHostState() }
     KaigiScaffold(
         modifier = modifier,
+        snackbarHostState = snackbarHostState,
         topBar = {
             SessionsTopBar(
                 pagerContentsScrollState,
@@ -149,6 +157,12 @@ fun Sessions(
             )
         }
     ) { innerPadding ->
+        AppErrorSnackbarEffect(
+            appError = uiModel.appError,
+            snackBarHostState = snackbarHostState,
+            onAppErrorNotified = onAppErrorNotified,
+            onRetryButtonClick = onRetryButtonClick
+        )
         Column {
             when (scheduleState) {
                 is Error -> {
@@ -509,7 +523,8 @@ fun SessionsTimetablePreview() {
             uiModel = SessionsUiModel(
                 state = Success(DroidKaigiSchedule.fake()),
                 isFilterOn = false,
-                isTimetable = true
+                isTimetable = true,
+                appError = null
             ),
             showNavigationIcon = true,
             onNavigationIconClick = {},
@@ -517,6 +532,8 @@ fun SessionsTimetablePreview() {
             onFavoriteClick = { _, _ -> },
             onSearchClick = {},
             onToggleTimetableClick = {},
+            onRetryButtonClick = {},
+            onAppErrorNotified = {},
         )
     }
 }
@@ -529,7 +546,8 @@ fun SessionsSessionListPreview() {
             uiModel = SessionsUiModel(
                 state = Success(DroidKaigiSchedule.fake()),
                 isFilterOn = false,
-                isTimetable = false
+                isTimetable = false,
+                appError = null
             ),
             showNavigationIcon = true,
             onNavigationIconClick = {},
@@ -537,6 +555,8 @@ fun SessionsSessionListPreview() {
             onFavoriteClick = { _, _ -> },
             onSearchClick = {},
             onToggleTimetableClick = {},
+            onRetryButtonClick = {},
+            onAppErrorNotified = {},
         )
     }
 }
@@ -549,14 +569,17 @@ fun SessionsLoadingPreview() {
             uiModel = SessionsUiModel(
                 state = Loading,
                 isFilterOn = false,
-                isTimetable = true
+                isTimetable = true,
+                appError = null
             ),
+            showNavigationIcon = true,
             onNavigationIconClick = {},
             onTimetableClick = {},
             onFavoriteClick = { _, _ -> },
             onSearchClick = {},
             onToggleTimetableClick = {},
-            showNavigationIcon = true
+            onRetryButtonClick = {},
+            onAppErrorNotified = {},
         )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsUiModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsUiModel.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2022.feature.sessions
 
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.DroidKaigiSchedule
 import io.github.droidkaigi.confsched2022.model.Filters
 import io.github.droidkaigi.confsched2022.ui.UiLoadState
@@ -8,6 +9,7 @@ data class SessionsUiModel(
     val state: UiLoadState<DroidKaigiSchedule>,
     val isFilterOn: Boolean,
     val isTimetable: Boolean,
+    val appError: AppError?,
 ) {
     fun filter(filters: Filters): UiLoadState<DroidKaigiSchedule> =
         state.mapSuccess { it.filtered(filters) }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsViewModel.kt
@@ -4,12 +4,14 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.cash.molecule.AndroidUiDispatcher
 import app.cash.molecule.RecompositionClock.ContextClock
 import co.touchlab.kermit.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.Filters
 import io.github.droidkaigi.confsched2022.model.SessionsRepository
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
@@ -31,13 +33,12 @@ class SessionsViewModel @Inject constructor(
 
     private val filters = mutableStateOf(Filters())
     private val isTimetableMode = mutableStateOf(true)
+    private var appError by mutableStateOf<AppError?>(null)
 
-    private val moleculeScope =
-        CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
+    val uiModel: State<SessionsUiModel> = run {
+        val moleculeScope =
+            CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
 
-    val uiModel: State<SessionsUiModel>
-
-    init {
         val ziplineScheduleModifierFlow = sessionsZipline.timetableModifier()
         val sessionScheduleFlow = sessionsRepository.droidKaigiScheduleFlow()
 
@@ -53,20 +54,38 @@ class SessionsViewModel @Inject constructor(
                 schedule
             }
         }.asLoadState()
-
-        uiModel = moleculeScope.moleculeComposeState(clock = ContextClock) {
+        moleculeScope.moleculeComposeState(clock = ContextClock) {
             val schedule by scheduleFlow.collectAsState(initial = UiLoadState.Loading)
 
             SessionsUiModel(
                 state = schedule,
                 isFilterOn = filters.value.filterFavorite,
                 isTimetable = isTimetableMode.value,
+                appError = appError,
             )
         }
     }
 
-    fun onToggleFilter() {
-        filters.value = filters.value.copy(filterFavorite = !filters.value.filterFavorite)
+    init {
+        refresh()
+    }
+
+    fun onRetryButtonClick() {
+        refresh()
+    }
+
+    private fun refresh() {
+        viewModelScope.launch {
+            try {
+                sessionsRepository.refresh()
+            } catch (error: AppError) {
+                appError = error
+            }
+        }
+    }
+
+    fun onAppErrorNotified() {
+        appError = null
     }
 
     fun onFavoriteToggle(sessionId: TimetableItemId, currentIsFavorite: Boolean) {


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)

- App error handring should be centralised
- If we throw an error in callabckFlow in Repository, the flow won't work anymore (will do?). So we don't refresh in the callbackFlow.
- 

## Links
- https://www.artima.com/articles/the-trouble-with-checked-exceptions

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
