### PR TITLE
remove elevation from fab on session detail

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -257,6 +258,7 @@ fun SessionDetailBottomAppBar(
             Spacer(modifier = Modifier.weight(1F))
 
             FloatingActionButton(
+                elevation = FloatingActionButtonDefaults.bottomAppBarFabElevation(),
                 onClick = {
                     onFavoriteClick(isFavorite)
                 }


### PR DESCRIPTION
## Issue
- close #708 

## Overview (Required)
- use FloatingActionButtonDefaults.bottomAppBarFabElevation() to remove the elevation.
- follow the design (Figma)
![Screen Shot 2022-09-24 at 17 17 33](https://user-images.githubusercontent.com/74723074/192088035-c92e0d05-847c-4b16-b0b4-c7f76bacd9c6.png)

## Links
- [Figma (DroidKaigi-2022-Conference-App)](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/74723074/192088139-c9561197-de9e-47f7-9b00-6ed45ded9935.png" width="300" /> <img src="https://user-images.githubusercontent.com/74723074/192088140-fa9b0b65-9250-4da5-bb9a-a360decaf4f1.png" width="300" /> | <img src="https://user-images.githubusercontent.com/74723074/192088187-b57ad177-6a5a-4365-9831-4deb83a2c75d.png" width="300" /> <img src="https://user-images.githubusercontent.com/74723074/192088190-d5f91ec9-d9f7-426e-9c56-27c24a9c85d9.png" width="300" />
