### PR TITLE
Using method reference for better memorization.

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -107,9 +107,7 @@ fun KaigiApp(
                 drawerSheetContent = {
                     DrawerSheetContent(
                         selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem,
-                        onClickDrawerItem = { drawerItem ->
-                            kaigiAppScaffoldState.navigate(drawerItem)
-                        }
+                        onClickDrawerItem = kaigiAppScaffoldState::navigate,
                     )
                 }
             ) {


### PR DESCRIPTION
## Issue
- Attempt to close 526, but I think this PR is not enough.

## Overview (Required)
- AS-IS: callback using `viewModel.method` are not effectively remembered, because `viewModel` is not a stable type.
- TO-BE: using method reference instead because method reference capture the viewModel reference when it (method referenc) is created, so the value of `viewModel` doesn't affect the stabability of method reference. In another word, it is stable.

## Links
- More details about investigating this can be found here: https://github.com/DroidKaigi/conference-app-2022/issues/526#issuecomment-1251030842

## Screenshot
Before | After
:--: | :--:
<video src="https://user-images.githubusercontent.com/1776230/192101786-0ce834ba-bca1-4839-a51f-603d50910aa4.mov">|<video src="https://user-images.githubusercontent.com/1776230/192101815-628da50c-18a2-483f-b9ad-3dfe3ff9616b.mov">


