### PR TITLE
Pinch and zoom for floor map

### DIFF
--- a/feature/map/src/main/java/io/github/droidkaigi/confsched2022/feature/map/Map.kt
+++ b/feature/map/src/main/java/io/github/droidkaigi/confsched2022/feature/map/Map.kt
@@ -2,14 +2,22 @@ package io.github.droidkaigi.confsched2022.feature.map
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import dev.icerock.moko.resources.compose.stringResource
@@ -55,10 +63,27 @@ fun Map(
                 .padding(innerPadding),
             contentAlignment = Alignment.Center
         ) {
+            val minScale = 1f
+            val maxScale = 3f
+            var scale by remember { mutableStateOf(minScale) }
+            var offset by remember { mutableStateOf(Offset.Zero) }
+            val state = rememberTransformableState { zoomChange, offsetChange, _ ->
+                scale *= zoomChange
+                offset += offsetChange
+            }
             Image(
                 painter = painterResource(id = R.drawable.map),
                 contentDescription = "Floor map",
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier
+                    .transformable(state = state)
+                    .graphicsLayer(
+                        scaleX = maxOf(minScale, minOf(maxScale, scale)),
+                        scaleY = maxOf(minScale, minOf(maxScale, scale)),
+                        translationX = offset.x,
+                        translationY = offset.y,
+                    )
+                    .fillMaxSize()
+                    .padding(16.dp)
             )
         }
     }

--- a/feature/map/src/main/java/io/github/droidkaigi/confsched2022/feature/map/Map.kt
+++ b/feature/map/src/main/java/io/github/droidkaigi/confsched2022/feature/map/Map.kt
@@ -77,8 +77,8 @@ fun Map(
                 modifier = Modifier
                     .transformable(state = state)
                     .graphicsLayer(
-                        scaleX = maxOf(minScale, minOf(maxScale, scale)),
-                        scaleY = maxOf(minScale, minOf(maxScale, scale)),
+                        scaleX = scale.coerceIn(minScale, maxScale),
+                        scaleY = scale.coerceIn(minScale, maxScale),
                         translationX = offset.x,
                         translationY = offset.y,
                     )


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2022/issues/706

## Overview (Required)

- Pinch and zoom for floor map

## Links

I developed based on  "Multitouch: Panning, zooming, rotating".
- https://developer.android.com/jetpack/compose/gestures?authuser=1#multitouch

## Screenshot

<img src="https://user-images.githubusercontent.com/25548003/192106746-e34bb3d6-40a8-47b5-b11d-af794a48d720.png" width="300" />
