### PR TITLE
:recycle: Update Introduce error handring to contributors

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/contributors/DataContributorsRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/contributors/DataContributorsRepository.kt
@@ -3,27 +3,30 @@ package io.github.droidkaigi.confsched2022.data.contributors
 import io.github.droidkaigi.confsched2022.model.Contributor
 import io.github.droidkaigi.confsched2022.model.ContributorsRepository
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 
 // TODO: Move to core-testing, once contributors server is created
 public class DataContributorsRepository(
     private val contributorsApi: ContributorsApi,
 ) : ContributorsRepository {
+    private val contributorsStateFlow =
+        MutableStateFlow<PersistentList<Contributor>>(persistentListOf())
+
     override fun contributors(): Flow<PersistentList<Contributor>> {
         return callbackFlow {
-            send(
-                contributorsApi
-                    .contributors()
-                    .toPersistentList()
-            )
-            awaitClose { }
+            contributorsStateFlow.collect {
+                send(it)
+            }
         }
     }
 
     override suspend fun refresh() {
-        TODO("Not yet implemented")
+        contributorsStateFlow.value = contributorsApi
+            .contributors()
+            .toPersistentList()
     }
 }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/contributors/FakeContributorsRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/contributors/FakeContributorsRepository.kt
@@ -14,6 +14,5 @@ public class FakeContributorsRepository : ContributorsRepository {
     }
 
     override suspend fun refresh() {
-        TODO("Not yet implemented")
     }
 }

--- a/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/common/AppErrorSnackbarEffect.kt
+++ b/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/common/AppErrorSnackbarEffect.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.confsched2022.feature.announcement
+package io.github.droidkaigi.confsched2022.feature.common
 
 import androidx.compose.material3.SnackbarDuration.Long
 import androidx.compose.material3.SnackbarHostState

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -37,6 +37,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiColors
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.AnnouncementsByDate
 import io.github.droidkaigi.confsched2022.model.fakes
 import io.github.droidkaigi.confsched2022.strings.Strings

--- a/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,6 +21,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.components.UsernameRow
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.Contributor
 import io.github.droidkaigi.confsched2022.model.fakes
 import io.github.droidkaigi.confsched2022.strings.Strings
@@ -38,6 +41,8 @@ fun ContributorsScreenRoot(
         uiModel = uiModel,
         showNavigationIcon = showNavigationIcon,
         onNavigationIconClick = onNavigationIconClick,
+        onRetryButtonClick = { viewModel.onRetryButtonClick() },
+        onAppErrorNotified = { viewModel.onAppErrorNotified() },
         onLinkClick = onLinkClick
     )
 }
@@ -47,10 +52,15 @@ fun Contributors(
     uiModel: ContributorsUiModel,
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    onRetryButtonClick: () -> Unit,
+    onAppErrorNotified: () -> Unit,
     onLinkClick: (url: String, packageName: String?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
     KaigiScaffold(
+        snackbarHostState = snackbarHostState,
         modifier = modifier,
         topBar = {
             KaigiTopAppBar(
@@ -64,9 +74,17 @@ fun Contributors(
             )
         }
     ) { innerPadding ->
+        AppErrorSnackbarEffect(
+            appError = uiModel.appError,
+            snackBarHostState = snackbarHostState,
+            onAppErrorNotified = onAppErrorNotified,
+            onRetryButtonClick = onRetryButtonClick
+        )
         Box {
             when (uiModel.state) {
-                is Error -> TODO()
+                is Error -> {
+                    // Do nothing
+                }
                 Loading -> Box(
                     modifier = Modifier.padding(innerPadding).fillMaxSize(),
                     contentAlignment = Alignment.Center,
@@ -103,10 +121,13 @@ fun ContributorsPreview() {
             uiModel = ContributorsUiModel(
                 state = Success(
                     Contributor.fakes()
-                )
+                ),
+                appError = null,
             ),
             showNavigationIcon = true,
             onNavigationIconClick = {},
+            onRetryButtonClick = {},
+            onAppErrorNotified = {},
             onLinkClick = { _, _ -> },
         )
     }

--- a/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
+++ b/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/Contributors.kt
@@ -21,7 +21,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.components.UsernameRow
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.Contributor
 import io.github.droidkaigi.confsched2022.model.fakes
 import io.github.droidkaigi.confsched2022.strings.Strings

--- a/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsUiModel.kt
+++ b/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsUiModel.kt
@@ -1,7 +1,11 @@
 package io.github.droidkaigi.confsched2022.feature.contributors
 
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.Contributor
 import io.github.droidkaigi.confsched2022.ui.UiLoadState
 import kotlinx.collections.immutable.PersistentList
 
-data class ContributorsUiModel(val state: UiLoadState<PersistentList<Contributor>>)
+data class ContributorsUiModel(
+    val state: UiLoadState<PersistentList<Contributor>>,
+    val appError: AppError?
+)

--- a/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsViewModel.kt
+++ b/feature/contributors/src/main/java/io/github/droidkaigi/confsched2022/feature/contributors/ContributorsViewModel.kt
@@ -3,33 +3,64 @@ package io.github.droidkaigi.confsched2022.feature.contributors
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.cash.molecule.AndroidUiDispatcher
 import app.cash.molecule.RecompositionClock.ContextClock
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.ContributorsRepository
 import io.github.droidkaigi.confsched2022.ui.UiLoadState
 import io.github.droidkaigi.confsched2022.ui.asLoadState
 import io.github.droidkaigi.confsched2022.ui.moleculeComposeState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ContributorsViewModel @Inject constructor(
-    contributorsRepository: ContributorsRepository,
+    private val contributorsRepository: ContributorsRepository,
 ) : ViewModel() {
     private val moleculeScope =
         CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
 
-    val uiModel: State<ContributorsUiModel>
+    private val contributorsFlow = contributorsRepository
+        .contributors()
+        .asLoadState()
+
+    private var appError by mutableStateOf<AppError?>(null)
+
+    val uiModel: State<ContributorsUiModel> = moleculeScope.moleculeComposeState(
+        clock = ContextClock
+    ) {
+        val contributorLoadState by contributorsFlow.collectAsState(initial = UiLoadState.Loading)
+        ContributorsUiModel(
+            state = contributorLoadState,
+            appError = appError
+        )
+    }
 
     init {
-        val dataFlow = contributorsRepository.contributors().asLoadState()
+        refresh()
+    }
 
-        uiModel = moleculeScope.moleculeComposeState(clock = ContextClock) {
-            val data by dataFlow.collectAsState(initial = UiLoadState.Loading)
-            ContributorsUiModel(data)
+    fun onRetryButtonClick() {
+        refresh()
+    }
+
+    private fun refresh() {
+        viewModelScope.launch {
+            try {
+                contributorsRepository.refresh()
+            } catch (e: AppError) {
+                appError = e
+            }
         }
+    }
+
+    fun onAppErrorNotified() {
+        appError = null
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -66,7 +66,7 @@ import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day
 import io.github.droidkaigi.confsched2022.model.DroidKaigiSchedule
 import io.github.droidkaigi.confsched2022.model.TimetableItemId


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Error handling has been implemented as in the Contributors screen, etc.
- [Moved the AppErrorSnackbarEffect class package to common.](https://github.com/DroidKaigi/conference-app-2022/pull/741/commits/4fe77ca61da80c681f4f1340c7d9da9ef38da5d3)

## Links
- https://github.com/DroidKaigi/conference-app-2022/pull/668#issuecomment-1256852203

## Movie

https://user-images.githubusercontent.com/13657682/192120560-92f018fb-6bff-4151-b87b-2ab56fe76beb.mp4

![after](https://user-images.githubusercontent.com/13657682/192120641-ddae6200-be23-43ec-a664-a43db39c1a7a.gif)