### PR TITLE
:recycle: Update Introduce error handring to sessiondetail

### DIFF
--- a/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/common/AppErrorSnackbarEffect.kt
+++ b/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/common/AppErrorSnackbarEffect.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.confsched2022.feature.announcement
+package io.github.droidkaigi.confsched2022.feature.common
 
 import androidx.compose.material3.SnackbarDuration.Long
 import androidx.compose.material3.SnackbarHostState

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -37,6 +37,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiColors
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.AnnouncementsByDate
 import io.github.droidkaigi.confsched2022.model.fakes
 import io.github.droidkaigi.confsched2022.strings.Strings

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -60,7 +60,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTag
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2022.designsystem.theme.TimetableItemColor
-import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.Lang
 import io.github.droidkaigi.confsched2022.model.MultiLangText
 import io.github.droidkaigi.confsched2022.model.TimetableAsset

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -59,6 +60,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTag
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2022.designsystem.theme.TimetableItemColor
+import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.Lang
 import io.github.droidkaigi.confsched2022.model.MultiLangText
 import io.github.droidkaigi.confsched2022.model.TimetableAsset
@@ -97,6 +99,8 @@ fun SessionDetailScreenRoot(
     SessionDetailScreen(
         modifier = modifier,
         uiModel = uiModel,
+        onRetryButtonClick = { viewModel.onRetryButtonClick() },
+        onAppErrorNotified = { viewModel.onAppErrorNotified() },
         onBackIconClick = onBackIconClick,
         onFavoriteClick = { currentFavorite ->
             viewModel.onFavoriteToggle(timetableItemId, currentFavorite)
@@ -147,6 +151,8 @@ fun SessionDetailTopAppBar(
 @Composable
 fun SessionDetailScreen(
     uiModel: SessionDetailUiModel,
+    onRetryButtonClick: () -> Unit,
+    onAppErrorNotified: () -> Unit,
     modifier: Modifier = Modifier,
     onBackIconClick: () -> Unit = {},
     onFavoriteClick: (Boolean) -> Unit = {},
@@ -154,10 +160,11 @@ fun SessionDetailScreen(
     onNavigateFloorMapClick: () -> Unit = {},
     onRegisterCalendarClick: (TimetableItem) -> Unit = {},
 ) {
-
     val uiState = uiModel.state
+    val snackbarHostState = remember { SnackbarHostState() }
 
     KaigiScaffold(
+        snackbarHostState = snackbarHostState,
         topBar = {
             SessionDetailTopAppBar(
                 onBackIconClick = onBackIconClick,
@@ -178,9 +185,17 @@ fun SessionDetailScreen(
             }
         },
     ) { innerPadding ->
+        AppErrorSnackbarEffect(
+            appError = uiModel.appError,
+            snackBarHostState = snackbarHostState,
+            onAppErrorNotified = onAppErrorNotified,
+            onRetryButtonClick = onRetryButtonClick
+        )
         Box(modifier = Modifier.padding(innerPadding)) {
             when (uiState) {
-                is Error -> TODO()
+                is Error -> {
+                    // Do nothing
+                }
                 Loading ->
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         CircularProgressIndicator()
@@ -635,8 +650,11 @@ fun PreviewSessionDetailScreen() {
     KaigiTheme {
         SessionDetailScreen(
             uiModel = SessionDetailUiModel(
-                Success(TimetableItemWithFavorite.fake())
-            )
+                state = Success(TimetableItemWithFavorite.fake()),
+                appError = null,
+            ),
+            onRetryButtonClick = {},
+            onAppErrorNotified = {},
         )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetailUiModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetailUiModel.kt
@@ -1,6 +1,10 @@
 package io.github.droidkaigi.confsched2022.feature.sessions
 
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.TimetableItemWithFavorite
 import io.github.droidkaigi.confsched2022.ui.UiLoadState
 
-data class SessionDetailUiModel(val state: UiLoadState<TimetableItemWithFavorite>)
+data class SessionDetailUiModel(
+    val state: UiLoadState<TimetableItemWithFavorite>,
+    val appError: AppError?
+)

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetailViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetailViewModel.kt
@@ -3,12 +3,15 @@ package io.github.droidkaigi.confsched2022.feature.sessions
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.cash.molecule.AndroidUiDispatcher
 import app.cash.molecule.RecompositionClock.ContextClock
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.SessionsRepository
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
 import io.github.droidkaigi.confsched2022.ui.UiLoadState
@@ -30,16 +33,22 @@ class SessionDetailViewModel @Inject constructor(
     private val timetableItemId: TimetableItemId =
         TimetableItemId(requireNotNull(savedStateHandle.get<String>("id")))
 
-    val uiModel: State<SessionDetailUiModel>
+    private var appError by mutableStateOf<AppError?>(null)
+
+    private val timetableItemFlow =
+        sessionsRepository.timetableItemFlow(timetableItemId).asLoadState()
+
+    val uiModel: State<SessionDetailUiModel> =
+        moleculeScope.moleculeComposeState(clock = ContextClock) {
+            val timetableItem by timetableItemFlow.collectAsState(initial = UiLoadState.Loading)
+            SessionDetailUiModel(
+                state = timetableItem,
+                appError = appError
+            )
+        }
 
     init {
-        val timetableItemFlow =
-            sessionsRepository.timetableItemFlow(timetableItemId).asLoadState()
-
-        uiModel = moleculeScope.moleculeComposeState(clock = ContextClock) {
-            val timetableItem by timetableItemFlow.collectAsState(initial = UiLoadState.Loading)
-            SessionDetailUiModel(timetableItem)
-        }
+        refresh()
     }
 
     fun onFavoriteToggle(sessionId: TimetableItemId, currentIsFavorite: Boolean) {
@@ -48,5 +57,23 @@ class SessionDetailViewModel @Inject constructor(
                 sessionId, !currentIsFavorite
             )
         }
+    }
+
+    fun onRetryButtonClick() {
+        refresh()
+    }
+
+    private fun refresh() {
+        viewModelScope.launch {
+            try {
+                sessionsRepository.refresh()
+            } catch (e: AppError) {
+                appError = e
+            }
+        }
+    }
+
+    fun onAppErrorNotified() {
+        appError = null
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -66,7 +66,7 @@ import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day
 import io.github.droidkaigi.confsched2022.model.DroidKaigiSchedule
 import io.github.droidkaigi.confsched2022.model.TimetableItemId


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- Error handling has been implemented as in the session detail screen, etc.

## Links
- https://github.com/DroidKaigi/conference-app-2022/pull/668#issuecomment-1256852203

## Movie

https://user-images.githubusercontent.com/13657682/192123357-de3c1786-4a91-4239-b70d-eb7aa804ecb9.mp4

https://user-images.githubusercontent.com/13657682/192123362-f25d687c-6517-412d-97b5-e754474cbbdf.mp4