### PR TITLE
:recycle: Update Introduce error handring to staff

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/staff/DataStaffRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/staff/DataStaffRepository.kt
@@ -3,22 +3,29 @@ package io.github.droidkaigi.confsched2022.data.staff
 import io.github.droidkaigi.confsched2022.model.Staff
 import io.github.droidkaigi.confsched2022.model.StaffRepository
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 
 public class DataStaffRepository(
     private val staffApi: StaffApi
 ) : StaffRepository {
+    private val staffStateFlow =
+        MutableStateFlow<PersistentList<Staff>>(persistentListOf())
+
     override fun staff(): Flow<PersistentList<Staff>> {
         return callbackFlow {
-            send(
-                staffApi
-                    .staff()
-                    .toPersistentList()
-            )
-            awaitClose { }
+            staffStateFlow.collect {
+                send(it)
+            }
         }
+    }
+
+    override suspend fun refresh() {
+        staffStateFlow.value = staffApi
+            .staff()
+            .toPersistentList()
     }
 }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/staff/FakeStaffRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/staff/FakeStaffRepository.kt
@@ -12,4 +12,7 @@ public class FakeStaffRepository : StaffRepository {
     override fun staff(): Flow<PersistentList<Staff>> {
         return flowOf(staff)
     }
+
+    override suspend fun refresh() {
+    }
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/StaffRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/StaffRepository.kt
@@ -5,4 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 public interface StaffRepository {
     public fun staff(): Flow<PersistentList<Staff>>
+
+    public suspend fun refresh()
 }

--- a/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/common/AppErrorSnackbarEffect.kt
+++ b/core/ui/src/main/java/io/github/droidkaigi/confsched2022/feature/common/AppErrorSnackbarEffect.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.confsched2022.feature.announcement
+package io.github.droidkaigi.confsched2022.feature.common
 
 import androidx.compose.material3.SnackbarDuration.Long
 import androidx.compose.material3.SnackbarHostState

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -37,6 +37,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiColors
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.AnnouncementsByDate
 import io.github.droidkaigi.confsched2022.model.fakes
 import io.github.droidkaigi.confsched2022.strings.Strings

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -66,7 +66,7 @@ import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.DroidKaigi2022Day
 import io.github.droidkaigi.confsched2022.model.DroidKaigiSchedule
 import io.github.droidkaigi.confsched2022.model.TimetableItemId

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,6 +21,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.components.UsernameRow
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.Staff
 import io.github.droidkaigi.confsched2022.model.fakes
 import io.github.droidkaigi.confsched2022.strings.Strings
@@ -35,7 +38,15 @@ fun StaffScreenRoot(
     onLinkClick: (url: String, packageName: String?) -> Unit = { _, _ -> }
 ) {
     val uiModel by viewModel.uiModel
-    Staff(uiModel, showNavigationIcon, onNavigationIconClick, onLinkClick, modifier)
+    Staff(
+        uiModel = uiModel,
+        showNavigationIcon = showNavigationIcon,
+        onNavigationIconClick = onNavigationIconClick,
+        onRetryButtonClick = { viewModel.onRetryButtonClick() },
+        onAppErrorNotified = { viewModel.onAppErrorNotified() },
+        onLinkClick = onLinkClick,
+        modifier = modifier
+    )
 }
 
 @Composable
@@ -43,10 +54,15 @@ fun Staff(
     uiModel: StaffUiModel,
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    onRetryButtonClick: () -> Unit,
+    onAppErrorNotified: () -> Unit,
     onLinkClick: (url: String, packageName: String?) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
     KaigiScaffold(
+        snackbarHostState = snackbarHostState,
         topBar = {
             KaigiTopAppBar(
                 showNavigationIcon = showNavigationIcon,
@@ -59,9 +75,17 @@ fun Staff(
             )
         }
     ) { innerPadding ->
+        AppErrorSnackbarEffect(
+            appError = uiModel.appError,
+            snackBarHostState = snackbarHostState,
+            onAppErrorNotified = onAppErrorNotified,
+            onRetryButtonClick = onRetryButtonClick
+        )
         Box(modifier = Modifier.padding(innerPadding)) {
             when (uiModel.state) {
-                is Error -> TODO()
+                is Error -> {
+                    // Do nothing
+                }
                 is Loading -> Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
@@ -97,10 +121,13 @@ fun StaffPreview() {
             uiModel = StaffUiModel(
                 state = Success(
                     Staff.fakes()
-                )
+                ),
+                appError = null,
             ),
             showNavigationIcon = true,
             onNavigationIconClick = {},
+            onRetryButtonClick = {},
+            onAppErrorNotified = {},
             onLinkClick = { _, _ -> },
         )
     }

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/Staff.kt
@@ -21,7 +21,7 @@ import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
 import io.github.droidkaigi.confsched2022.designsystem.components.UsernameRow
 import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2022.feature.announcement.AppErrorSnackbarEffect
+import io.github.droidkaigi.confsched2022.feature.common.AppErrorSnackbarEffect
 import io.github.droidkaigi.confsched2022.model.Staff
 import io.github.droidkaigi.confsched2022.model.fakes
 import io.github.droidkaigi.confsched2022.strings.Strings

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/StaffUiModel.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/StaffUiModel.kt
@@ -1,7 +1,11 @@
 package io.github.droidkaigi.confsched2022.feature.staff
 
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.Staff
 import io.github.droidkaigi.confsched2022.ui.UiLoadState
 import kotlinx.collections.immutable.PersistentList
 
-data class StaffUiModel(val state: UiLoadState<PersistentList<Staff>>)
+data class StaffUiModel(
+    val state: UiLoadState<PersistentList<Staff>>,
+    val appError: AppError?,
+)

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/StaffViewModel.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2022/feature/staff/StaffViewModel.kt
@@ -3,33 +3,62 @@ package io.github.droidkaigi.confsched2022.feature.staff
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.cash.molecule.AndroidUiDispatcher
 import app.cash.molecule.RecompositionClock.ContextClock
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.droidkaigi.confsched2022.model.AppError
 import io.github.droidkaigi.confsched2022.model.StaffRepository
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Loading
 import io.github.droidkaigi.confsched2022.ui.asLoadState
 import io.github.droidkaigi.confsched2022.ui.moleculeComposeState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class StaffViewModel @Inject constructor(
-    staffRepository: StaffRepository,
+    private val staffRepository: StaffRepository,
 ) : ViewModel() {
     private val moleculeScope =
         CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
 
-    val uiModel: State<StaffUiModel>
+    private val staffFlow = staffRepository
+        .staff()
+        .asLoadState()
+
+    private var appError by mutableStateOf<AppError?>(null)
+
+    val uiModel: State<StaffUiModel> = moleculeScope.moleculeComposeState(clock = ContextClock) {
+        val staffState by staffFlow.collectAsState(initial = Loading)
+        StaffUiModel(
+            state = staffState,
+            appError = appError,
+        )
+    }
 
     init {
-        val dataFlow = staffRepository.staff().asLoadState()
+        refresh()
+    }
 
-        uiModel = moleculeScope.moleculeComposeState(clock = ContextClock) {
-            val data by dataFlow.collectAsState(initial = Loading)
-            StaffUiModel(data)
+    fun onRetryButtonClick() {
+        refresh()
+    }
+
+    private fun refresh() {
+        viewModelScope.launch {
+            try {
+                staffRepository.refresh()
+            } catch (e: AppError) {
+                appError = e
+            }
         }
+    }
+
+    fun onAppErrorNotified() {
+        appError = null
     }
 }


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- Error handling has been implemented as in the Announcements screen, etc.
- [Moved the AppErrorSnackbarEffect class package to common.](https://github.com/DroidKaigi/conference-app-2022/commit/feea7db2bb8e4a6358875e38926ad78c3cd38313)

## Links
- https://github.com/DroidKaigi/conference-app-2022/pull/668#issuecomment-1256852203

## Movie

https://user-images.githubusercontent.com/13657682/192123828-4dfe86bf-6236-4a9c-a600-f21ab8a37ce1.mp4

https://user-images.githubusercontent.com/13657682/192123834-998b72da-d4d4-4a8e-a2ce-7ee7e24d3180.mp4