### PR TITLE
[iOS] Enable links in announcements

### DIFF
--- a/app-ios/Sources/AnnouncementFeature/AnnouncementItemView.swift
+++ b/app-ios/Sources/AnnouncementFeature/AnnouncementItemView.swift
@@ -16,7 +16,7 @@ struct AnnouncementItemView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text(announcement.title)
                     .font(.system(size: 16, weight: .semibold))
-                Text(announcement.content)
+                Text(.init(announcement.content))
                     .font(.system(size: 16, weight: .regular))
             }
         }


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR adds a trick to enable links in announcements

## Links
- https://stackoverflow.com/questions/57744392/

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5673994/192137321-a78d4d1f-9043-4075-a1b3-f965e98ff9e7.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5673994/192137336-e0397d38-447e-4220-8cd4-37b437983272.png" width="300" />
