### PR TITLE
[iOS] enhance Sponsor view scroll

### DIFF
--- a/app-ios/Sources/SponsorFeature/SponsorView.swift
+++ b/app-ios/Sources/SponsorFeature/SponsorView.swift
@@ -51,7 +51,8 @@ public let sponsorReducer = Reducer<SponsorState, SponsorAction, SponsorEnvironm
                 await subscriber.send(
                     .refreshResponse(
                         TaskResult {
-                            await prefetchImage(from: result.compactMap { URL(string: $0.logo) })
+                            let prefetcher = ImagePrefetcher(urls: result.compactMap { URL(string: $0.logo) }, options: nil)
+                            prefetcher.start()
                             return result
                         }
                     )
@@ -74,15 +75,6 @@ public let sponsorReducer = Reducer<SponsorState, SponsorAction, SponsorEnvironm
         state.sheetItem = nil
         return .none
     }
-}
-
-private func prefetchImage(from urls: [URL]) async {
-    await withCheckedContinuation({ continuation in
-        let prefetcher = ImagePrefetcher(urls: urls, options: nil) { _, _, _ in
-            continuation.resume(returning: ())
-        }
-        prefetcher.start()
-    })
 }
 
 public struct SponsorView: View {

--- a/app-ios/Sources/SponsorFeature/SponsorView.swift
+++ b/app-ios/Sources/SponsorFeature/SponsorView.swift
@@ -1,6 +1,7 @@
 import appioscombined
 import CommonComponents
 import ComposableArchitecture
+import Kingfisher
 import Model
 import SafariView
 import SwiftUI
@@ -50,7 +51,8 @@ public let sponsorReducer = Reducer<SponsorState, SponsorAction, SponsorEnvironm
                 await subscriber.send(
                     .refreshResponse(
                         TaskResult {
-                            result
+                            await prefetchImage(from: result.compactMap { URL(string: $0.logo) })
+                            return result
                         }
                     )
                 )
@@ -72,6 +74,15 @@ public let sponsorReducer = Reducer<SponsorState, SponsorAction, SponsorEnvironm
         state.sheetItem = nil
         return .none
     }
+}
+
+private func prefetchImage(from urls: [URL]) async {
+    await withCheckedContinuation({ continuation in
+        let prefetcher = ImagePrefetcher(urls: urls, options: nil) { _, _, _ in
+            continuation.resume(returning: ())
+        }
+        prefetcher.start()
+    })
 }
 
 public struct SponsorView: View {


### PR DESCRIPTION
## Issue
- close #643

## Overview (Required)
- This may not be the best way, but we improved scrollability by storage caching all sponsor images.
- Especially when the sponsor view is displayed for the second time, I think it has improved more than before.
- There may be a better way, but I couldn't think of any other improvements🙏

## Links
- 

## Screenshot
Before | After
:--: | :--:
<video src="https://user-images.githubusercontent.com/5406001/192141963-a0e4ba0a-90e0-407a-8e47-e67f9f07328a.mp4" > | <video src="https://user-images.githubusercontent.com/5406001/192141975-e1dfa5a4-f9d6-4dd6-b0f2-5e9344030d7c.mp4" />







