### PR TITLE
add SearchEmptyScreen that displays when the search for sessions hits no result.

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/DroidKaigiSchedule.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/DroidKaigiSchedule.kt
@@ -43,3 +43,7 @@ public data class DroidKaigiSchedule(
 public fun DroidKaigiSchedule.Companion.fake(): DroidKaigiSchedule {
     return of(Timetable.fake())
 }
+
+public fun DroidKaigiSchedule.Companion.empty(): DroidKaigiSchedule {
+    return of(Timetable())
+}

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -518,7 +519,7 @@ private fun SearchEmptyScreen(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center,
     ) {
         Column(
-            modifier = Modifier.wrapContentWidth(),
+            modifier = Modifier.wrapContentSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState


### PR DESCRIPTION
## Issue
- close #597

## Overview (Required)
- add SearchEmptyScreen that displays when the search for sessions hits no result.
- add the judgment whether showing SearchedItemListField or SearchEmptyScreen by referring to DroidKaigiSchedule.

## Screenshot
Before | After
:--: | :--:
<img src=https://user-images.githubusercontent.com/5121183/192145920-3bdc2379-ddb6-427f-b18d-e7f62413d0bf.png  width=300> | <img src=https://user-images.githubusercontent.com/5121183/192145918-c861e2f9-f337-4229-b509-5f7403143890.png  width=300>




