### PR TITLE
Delete composition locals and make it event

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -42,7 +42,6 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -80,10 +79,11 @@ import io.github.droidkaigi.confsched2022.feature.staff.StaffNavGraph
 import io.github.droidkaigi.confsched2022.feature.staff.staffNavGraph
 import io.github.droidkaigi.confsched2022.impl.AndroidCalendarRegistration
 import io.github.droidkaigi.confsched2022.impl.AndroidShareManager
+import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
 import io.github.droidkaigi.confsched2022.strings.Strings
-import io.github.droidkaigi.confsched2022.ui.LocalCalendarRegistration
-import io.github.droidkaigi.confsched2022.ui.LocalShareManager
+import io.github.droidkaigi.confsched2022.ui.CalendarRegistration
+import io.github.droidkaigi.confsched2022.ui.ShareManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -96,71 +96,69 @@ fun KaigiApp(
         rememberKaigiExternalNavigationController(),
 ) {
     KaigiTheme {
-        CompositionLocalProvider(
-            LocalShareManager provides AndroidShareManager(LocalContext.current),
-            LocalCalendarRegistration provides AndroidCalendarRegistration(LocalContext.current),
+        val usePersistentNavigationDrawer = windowSizeClass.usePersistentNavigationDrawer
+        KaigiAppDrawer(
+            kaigiAppScaffoldState = kaigiAppScaffoldState,
+            showPermanently = usePersistentNavigationDrawer,
+            drawerSheetContent = {
+                DrawerSheetContent(
+                    selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem,
+                    onClickDrawerItem = kaigiAppScaffoldState::navigate,
+                )
+            }
         ) {
-            val usePersistentNavigationDrawer = windowSizeClass.usePersistentNavigationDrawer
-            KaigiAppDrawer(
-                kaigiAppScaffoldState = kaigiAppScaffoldState,
-                showPermanently = usePersistentNavigationDrawer,
-                drawerSheetContent = {
-                    DrawerSheetContent(
-                        selectedDrawerItem = kaigiAppScaffoldState.selectedDrawerItem,
-                        onClickDrawerItem = kaigiAppScaffoldState::navigate,
-                    )
-                }
+            NavHost(
+                modifier = Modifier,
+                navController = kaigiAppScaffoldState.navController,
+                startDestination = SessionsNavGraph.sessionRoute,
             ) {
-                NavHost(
-                    modifier = Modifier,
-                    navController = kaigiAppScaffoldState.navController,
-                    startDestination = SessionsNavGraph.sessionRoute,
-                ) {
-                    val showNavigationIcon = !usePersistentNavigationDrawer
-                    sessionsNavGraph(
-                        showNavigationIcon = showNavigationIcon,
-                        onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
-                        onBackIconClick = kaigiAppScaffoldState::onBackIconClick,
-                        onSearchIconClick = kaigiAppScaffoldState::onSearchClick,
-                        onTimetableClick = kaigiAppScaffoldState::onTimeTableClick,
-                        onNavigateFloorMapClick = kaigiAppScaffoldState::onNavigateFloorMapClick,
-                    )
-                    contributorsNavGraph(
-                        showNavigationIcon = showNavigationIcon,
-                        onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
-                        onLinkClick = kaigiExternalNavigationController::navigate,
-                    )
-                    aboutNavGraph(
-                        showNavigationIcon = showNavigationIcon,
-                        onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
-                        onLinkClick = kaigiExternalNavigationController::navigate,
-                        onStaffListClick = kaigiAppScaffoldState::onStaffListClick,
-                        onLicenseClick = kaigiExternalNavigationController::navigateToOssLicense,
-                    )
-                    staffNavGraph(
-                        showNavigationIcon = showNavigationIcon,
-                        onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
-                        onLinkClick = kaigiExternalNavigationController::navigate,
-                    )
-                    mapGraph(
-                        showNavigationIcon = showNavigationIcon,
-                        onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
-                    )
-                    announcementGraph(
-                        showNavigationIcon = showNavigationIcon,
-                        onLinkClick = kaigiExternalNavigationController::navigate,
-                        onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
-                    )
-                    settingNavGraph(
-                        showNavigationIcon,
-                        kaigiAppScaffoldState::onNavigationClick
-                    )
-                    sponsorsNavGraph(
-                        showNavigationIcon = showNavigationIcon,
-                        onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
-                        onItemClick = kaigiExternalNavigationController::navigate
-                    )
-                }
+                val showNavigationIcon = !usePersistentNavigationDrawer
+                sessionsNavGraph(
+                    showNavigationIcon = showNavigationIcon,
+                    onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                    onBackIconClick = kaigiAppScaffoldState::onBackIconClick,
+                    onSearchIconClick = kaigiAppScaffoldState::onSearchClick,
+                    onTimetableClick = kaigiAppScaffoldState::onTimeTableClick,
+                    onShareClick = kaigiExternalNavigationController::onShareClick,
+                    onNavigateFloorMapClick = kaigiAppScaffoldState::onNavigateFloorMapClick,
+                    onRegisterCalendarClick =
+                    kaigiExternalNavigationController::onRegisterCalendarClick
+                )
+                contributorsNavGraph(
+                    showNavigationIcon = showNavigationIcon,
+                    onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                    onLinkClick = kaigiExternalNavigationController::navigate,
+                )
+                aboutNavGraph(
+                    showNavigationIcon = showNavigationIcon,
+                    onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                    onLinkClick = kaigiExternalNavigationController::navigate,
+                    onStaffListClick = kaigiAppScaffoldState::onStaffListClick,
+                    onLicenseClick = kaigiExternalNavigationController::navigateToOssLicense,
+                )
+                staffNavGraph(
+                    showNavigationIcon = showNavigationIcon,
+                    onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                    onLinkClick = kaigiExternalNavigationController::navigate,
+                )
+                mapGraph(
+                    showNavigationIcon = showNavigationIcon,
+                    onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                )
+                announcementGraph(
+                    showNavigationIcon = showNavigationIcon,
+                    onLinkClick = kaigiExternalNavigationController::navigate,
+                    onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                )
+                settingNavGraph(
+                    showNavigationIcon,
+                    kaigiAppScaffoldState::onNavigationClick
+                )
+                sponsorsNavGraph(
+                    showNavigationIcon = showNavigationIcon,
+                    onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                    onItemClick = kaigiExternalNavigationController::navigate
+                )
             }
         }
     }
@@ -390,15 +388,22 @@ fun ColumnScope.DrawerSheetContent(
 @Composable
 fun rememberKaigiExternalNavigationController(): KaigiExternalNavigationController {
     val context = LocalContext.current
+    val shareManager = AndroidShareManager(context)
+    val calendarRegistration = AndroidCalendarRegistration(context)
+
     return remember(context) {
         KaigiExternalNavigationController(
             context,
+            shareManager,
+            calendarRegistration
         )
     }
 }
 
 class KaigiExternalNavigationController(
     private val context: Context,
+    private val shareManager: ShareManager,
+    private val calendarRegistration: CalendarRegistration
 ) {
 
     fun navigate(
@@ -431,5 +436,21 @@ class KaigiExternalNavigationController(
 
     fun navigateToOssLicense() {
         context.startActivity(Intent(context, OssLicensesMenuActivity::class.java))
+    }
+
+    fun onShareClick(timeTableItem: TimetableItem) {
+        shareManager.share(
+            "${timeTableItem.title.currentLangTitle}\n" +
+                "https://droidkaigi.jp/2022/timetable/${timeTableItem.id.value}"
+        )
+    }
+
+    fun onRegisterCalendarClick(timeTableItem: TimetableItem) {
+        calendarRegistration.register(
+            startsAtMilliSeconds = timeTableItem.startsAt.toEpochMilliseconds(),
+            endsAtMilliSeconds = timeTableItem.endsAt.toEpochMilliseconds(),
+            title = timeTableItem.title.currentLangTitle,
+            location = timeTableItem.room.name.currentLangTitle,
+        )
     }
 }

--- a/core/ui/src/main/java/io/github/droidkaigi/confsched2022/ui/CalendarRegistration.kt
+++ b/core/ui/src/main/java/io/github/droidkaigi/confsched2022/ui/CalendarRegistration.kt
@@ -1,7 +1,5 @@
 package io.github.droidkaigi.confsched2022.ui
 
-import androidx.compose.runtime.staticCompositionLocalOf
-
 /**
  * Platform calendar registration feature wrapper
  */
@@ -16,8 +14,4 @@ interface CalendarRegistration {
         title: String,
         location: String,
     )
-}
-
-val LocalCalendarRegistration = staticCompositionLocalOf<CalendarRegistration> {
-    error("CompositionLocal LocalCalendarRegistration not present")
 }

--- a/core/ui/src/main/java/io/github/droidkaigi/confsched2022/ui/ShareManager.kt
+++ b/core/ui/src/main/java/io/github/droidkaigi/confsched2022/ui/ShareManager.kt
@@ -1,7 +1,5 @@
 package io.github.droidkaigi.confsched2022.ui
 
-import androidx.compose.runtime.staticCompositionLocalOf
-
 /**
  * Platform sharing feature wrapper
  */
@@ -13,8 +11,4 @@ interface ShareManager {
      * @param text share text
      */
     fun share(text: String)
-}
-
-val LocalShareManager = staticCompositionLocalOf<ShareManager> {
-    error("CompositionLocal LocalShareManager not present")
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -70,8 +70,6 @@ import io.github.droidkaigi.confsched2022.model.TimetableSpeaker
 import io.github.droidkaigi.confsched2022.model.fake
 import io.github.droidkaigi.confsched2022.model.secondLang
 import io.github.droidkaigi.confsched2022.strings.Strings
-import io.github.droidkaigi.confsched2022.ui.LocalCalendarRegistration
-import io.github.droidkaigi.confsched2022.ui.LocalShareManager
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Error
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Loading
 import io.github.droidkaigi.confsched2022.ui.UiLoadState.Success
@@ -84,15 +82,14 @@ import java.util.Locale
 @Composable
 fun SessionDetailScreenRoot(
     timetableItemId: TimetableItemId,
+    onShareClick: (TimetableItem) -> Unit,
+    onRegisterCalendarClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SessionDetailViewModel = hiltViewModel(),
     onBackIconClick: () -> Unit = {},
     onNavigateFloorMapClick: () -> Unit,
 ) {
     val uiModel by viewModel.uiModel
-
-    val shareManager = LocalShareManager.current
-    val calendarRegistration = LocalCalendarRegistration.current
 
     SessionDetailScreen(
         modifier = modifier,
@@ -101,20 +98,9 @@ fun SessionDetailScreenRoot(
         onFavoriteClick = { currentFavorite ->
             viewModel.onFavoriteToggle(timetableItemId, currentFavorite)
         },
-        onShareClick = {
-            shareManager.share(
-                "${it.title.currentLangTitle}\nhttps://droidkaigi.jp/2022/timetable/${it.id.value}"
-            )
-        },
+        onShareClick = onShareClick,
         onNavigateFloorMapClick = onNavigateFloorMapClick,
-        onRegisterCalendarClick = {
-            calendarRegistration.register(
-                startsAtMilliSeconds = it.startsAt.toEpochMilliseconds(),
-                endsAtMilliSeconds = it.endsAt.toEpochMilliseconds(),
-                title = it.title.currentLangTitle,
-                location = it.room.name.currentLangTitle,
-            )
-        },
+        onRegisterCalendarClick = onRegisterCalendarClick,
     )
 }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
 
 fun NavGraphBuilder.sessionsNavGraph(
@@ -13,6 +14,8 @@ fun NavGraphBuilder.sessionsNavGraph(
     onSearchIconClick: () -> Unit,
     onTimetableClick: (TimetableItemId) -> Unit,
     onNavigateFloorMapClick: () -> Unit,
+    onShareClick: (TimetableItem) -> Unit,
+    onRegisterCalendarClick: (TimetableItem) -> Unit
 ) {
     composable(route = SessionsNavGraph.sessionRoute) {
         SessionsScreenRoot(
@@ -37,6 +40,8 @@ fun NavGraphBuilder.sessionsNavGraph(
             timetableItemId = TimetableItemId(id),
             onBackIconClick = onBackIconClick,
             onNavigateFloorMapClick = onNavigateFloorMapClick,
+            onShareClick = onShareClick,
+            onRegisterCalendarClick = onRegisterCalendarClick
         )
     }
 


### PR DESCRIPTION
## Issue
- close #678 

## Overview (Required)
- Deleted some varuables related to LocalShareManager and LocalCalendarRegistration.
- Sharing sessions and Registering schedules are external function, threfore I moved instances and events to `KaigiExternalNavigationController`
    - Deleting CompositionLocalProvider makes the scope small and only provide functions to necessarry parts.

## Links
https://developer.android.com/jetpack/compose/compositionlocal?hl=#deciding
↑ I refered the link above.

## Screenshot
N/A
