### PR TITLE
add image placeholders

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     kotlinCompilerPluginClasspath(libs.composeCompiler)
     implementation(libs.coilCompose)
     implementation(libs.composeUiGoogleFonts)
+    implementation(libs.accompanistPlaceholder)
 }

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
@@ -53,10 +53,11 @@ fun UsernameRow(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .clip(CircleShape)
                         .placeholder(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
                             visible = true,
                             highlight = PlaceholderHighlight.shimmer(),
+                            shape = CircleShape,
                         )
                 )
             },

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
@@ -16,12 +16,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
+import com.google.accompanist.placeholder.PlaceholderDefaults
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material.placeholder
-import com.google.accompanist.placeholder.material.shimmer
+import com.google.accompanist.placeholder.material.shimmerHighlightColor
+import com.google.accompanist.placeholder.shimmer
+import io.github.droidkaigi.confsched2022.designsystem.theme.KaigiColors
 
 @Composable
 fun UsernameRow(
@@ -56,7 +60,11 @@ fun UsernameRow(
                         .placeholder(
                             color = MaterialTheme.colorScheme.surfaceVariant,
                             visible = true,
-                            highlight = PlaceholderHighlight.shimmer(),
+                            highlight = PlaceholderHighlight.shimmer(
+                                highlightColor = PlaceholderDefaults.shimmerHighlightColor(
+                                    backgroundColor = Color(KaigiColors.neutralVariantKeyColor60)
+                                ),
+                            ),
                             shape = CircleShape,
                         )
                 )

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/designsystem/components/UsernameRow.kt
@@ -1,8 +1,10 @@
 package io.github.droidkaigi.confsched2022.designsystem.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,7 +18,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import com.google.accompanist.placeholder.PlaceholderHighlight
+import com.google.accompanist.placeholder.material.placeholder
+import com.google.accompanist.placeholder.material.shimmer
 
 @Composable
 fun UsernameRow(
@@ -39,11 +44,22 @@ fun UsernameRow(
     ) {
         Spacer(modifier = Modifier.width(16.dp))
 
-        AsyncImage(
+        SubcomposeAsyncImage(
             model = iconUrl,
             contentDescription = null,
             alignment = Alignment.Center,
             contentScale = ContentScale.Fit,
+            loading = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(CircleShape)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                        )
+                )
+            },
             modifier = Modifier
                 .clip(CircleShape)
                 .size(60.dp)

--- a/feature/sponsors/build.gradle.kts
+++ b/feature/sponsors/build.gradle.kts
@@ -12,5 +12,6 @@ dependencies {
     implementation(libs.hiltNavigationCompose)
     implementation(libs.kermit)
     implementation(libs.accompanistFlowlayout)
+    implementation(libs.accompanistPlaceholder)
     implementation(libs.coilCompose)
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -202,10 +201,10 @@ private fun LazyGridScope.sponsorsGrid(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .clip(RoundedCornerShape(12.dp))
                             .placeholder(
                                 visible = true,
                                 highlight = PlaceholderHighlight.shimmer(),
+                                shape = RoundedCornerShape(12.dp),
                             ),
                     )
                 },

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2022/feature/sponsors/Sponsors.kt
@@ -25,10 +25,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import com.google.accompanist.placeholder.PlaceholderHighlight
+import com.google.accompanist.placeholder.material.placeholder
+import com.google.accompanist.placeholder.material.shimmer
 import dev.icerock.moko.resources.compose.stringResource
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiScaffold
 import io.github.droidkaigi.confsched2022.designsystem.components.KaigiTopAppBar
@@ -191,9 +195,20 @@ private fun LazyGridScope.sponsorsGrid(
                 )
                 .clickable { onItemClick(sponsor.link) }
         ) {
-            AsyncImage(
+            SubcomposeAsyncImage(
                 model = sponsor.logo,
                 contentDescription = sponsor.name,
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(12.dp))
+                            .placeholder(
+                                visible = true,
+                                highlight = PlaceholderHighlight.shimmer(),
+                            ),
+                    )
+                },
                 modifier = Modifier.fillMaxSize(),
             )
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,7 @@ daggerHiltAndroidCompiler = { module = "com.google.dagger:hilt-android-compiler"
 
 accompanistPager = { module = "com.google.accompanist:accompanist-pager", version.ref = "accompanist" }
 accompanistFlowlayout = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanist" }
+accompanistPlaceholder = { module = "com.google.accompanist:accompanist-placeholder-material", version.ref = "accompanist" }
 
 kotlinSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 


### PR DESCRIPTION
## Issue
- close #727 

## Overview (Required)
- adding image placeholders to `Sponsors` and `UsernameRow` with [Accompanist placeholder](https://google.github.io/accompanist/placeholder/)
- no change of any error images
- no change of speeker images on sesson screen 

## Screenshot

Before | After
:--: | :--:
<video controls src="https://user-images.githubusercontent.com/26954245/192182555-7147295f-1a91-415a-9f7a-87dee2638312.mp4" width="200"></video> | <video controls src="https://user-images.githubusercontent.com/26954245/192185197-dd47e214-4392-4679-b11f-271fe7ceafd5.mp4" width="200"></video> 
<video controls src="https://user-images.githubusercontent.com/26954245/192181779-1210e788-d43b-488f-9475-d083f49aa597.mp4" width="300"></video> | <video controls src="https://user-images.githubusercontent.com/26954245/192182685-ce42e313-d8f2-4ea4-bb06-5bc2fbd21a59.mp4" width="300"></video>
