### PR TITLE
:wrench: Fix Fixed to display both day and month in two digits.

### DIFF
--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -265,9 +265,12 @@ private fun LocalDate.convertString(): String {
     } else if (this.compareTo(yesterday) == 0) {
         stringResource(Strings.announcement_content_header_title_yesterday)
     } else {
-        "${this.year}/${this.month.value.toString().padStart(2, '0')}/${this.dayOfMonth}"
+        "${this.year}/${this.month.value.padDayOrMonth()}/${this.dayOfMonth.padDayOrMonth()}"
     }
 }
+
+private fun Int.padDayOrMonth(): String =
+    this.toString().padStart(2, '0')
 
 @Preview(showBackground = true)
 @Composable


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- As the title says.

## Links
- Nothing.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13657682/192216600-3de9a626-b4aa-4a74-b6c3-71ea30f7718e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13657682/192216587-72339f04-ae1e-42a7-a386-981bc157b769.png" width="300" />