### PR TITLE
[iOS] Improve the language setting detection

### DIFF
--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
@@ -1,11 +1,10 @@
 package io.github.droidkaigi.confsched2022.model
 
 import platform.Foundation.NSLocale
-import platform.Foundation.countryCode
-import platform.Foundation.currentLocale
+import platform.Foundation.preferredLanguages
 
 public actual fun getDefaultLocale(): Locale =
-    if (NSLocale.currentLocale.countryCode == "JP") {
+    if (NSLocale.preferredLanguages.first().toString().startsWith("ja")) {
         Locale.JAPAN
     } else {
         Locale.OTHER


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This PR changes to check the language code instead of the country code for a better language setting detection

## Links
- [iOSの言語設定を取得するベストプラクティス(Swift) - Qiita](https://qiita.com/uhooi/items/a9c9d8b923005028ce4e)
- [conference-app-2020/Lang.kt at 4c5533e4611d4bf6007284dd1f61db2fc92eb0ae · DroidKaigi/conference-app-2020](https://github.com/DroidKaigi/conference-app-2020/blob/4c5533e4611d4bf6007284dd1f61db2fc92eb0ae/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2020/model/Lang.kt)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5673994/192337195-c0c20e7e-c546-469e-bccb-07afac4cd03b.png" width="300" /><br>Language: English - Region: Japan | <img src="https://user-images.githubusercontent.com/5673994/192337348-c63a2e7e-332a-4c7d-a1dc-80af4a4a147d.png" width="300" /><br>Language: English - Region: Japan


