### PR TITLE
:recycle: Update Handle multiple URL in announcement

### DIFF
--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2022.feature.announcement
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -17,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
@@ -29,6 +29,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -189,15 +192,43 @@ fun AnnouncementContent(
     onLinkClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val regex = "(https)(:\\/\\/[\\w\\/:%#\\\$&\\?\\(\\)~\\.=\\+\\-]+)".toRegex()
+    val urlRegex = "(https)(://[\\w/:%#$&?()~.=+\\-]+)".toRegex()
+    val annotatedString = buildAnnotatedString {
+        pushStyle(
+            style = SpanStyle(
+                color = Color(type.contentTextColor)
+            )
+        )
+        append(content)
+        pop()
 
-    Column(
-        modifier = Modifier.clickable {
-            regex.find(content)?.let {
-                onLinkClick(it.value)
-            }
-        },
-    ) {
+        var lastIndex = 0
+        urlRegex.findAll(content).forEach { matchResult ->
+            val startIndex = content.indexOf(
+                string = matchResult.value,
+                startIndex = lastIndex,
+            )
+            val endIndex = startIndex + matchResult.value.length
+            addStyle(
+                style = SpanStyle(
+                    color = Color.Cyan,
+                    textDecoration = TextDecoration.Underline
+                ),
+                start = startIndex,
+                end = endIndex,
+            )
+            addStringAnnotation(
+                tag = matchResult.value,
+                annotation = matchResult.value,
+                start = startIndex,
+                end = endIndex,
+            )
+
+            lastIndex = endIndex
+        }
+    }
+
+    Column {
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -217,12 +248,22 @@ fun AnnouncementContent(
                 .height(16.dp)
                 .width(26.dp)
         )
-        Text(
+        ClickableText(
             modifier = modifier
                 .padding(start = 26.dp, top = 8.dp, bottom = 24.dp),
-            text = content,
+            text = annotatedString,
             style = MaterialTheme.typography.bodyLarge,
-            color = Color(type.contentTextColor),
+            onClick = { offset ->
+                urlRegex.findAll(content).forEach { matchResult ->
+                    annotatedString.getStringAnnotations(
+                        tag = matchResult.value,
+                        start = offset,
+                        end = offset
+                    ).firstOrNull()?.let {
+                        onLinkClick(matchResult.value)
+                    }
+                }
+            }
         )
     }
 }

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2022/feature/announcement/Announcements.kt
@@ -193,6 +193,9 @@ fun AnnouncementContent(
     modifier: Modifier = Modifier,
 ) {
     val urlRegex = "(https)(://[\\w/:%#$&?()~.=+\\-]+)".toRegex()
+    val findUrlResults = remember(content) {
+        urlRegex.findAll(content)
+    }
     val annotatedString = buildAnnotatedString {
         pushStyle(
             style = SpanStyle(
@@ -203,7 +206,7 @@ fun AnnouncementContent(
         pop()
 
         var lastIndex = 0
-        urlRegex.findAll(content).forEach { matchResult ->
+        findUrlResults.forEach { matchResult ->
             val startIndex = content.indexOf(
                 string = matchResult.value,
                 startIndex = lastIndex,
@@ -254,7 +257,7 @@ fun AnnouncementContent(
             text = annotatedString,
             style = MaterialTheme.typography.bodyLarge,
             onClick = { offset ->
-                urlRegex.findAll(content).forEach { matchResult ->
+                findUrlResults.forEach { matchResult ->
                     annotatedString.getStringAnnotations(
                         tag = matchResult.value,
                         start = offset,


### PR DESCRIPTION
## Issue
- close #721 

## Overview (Required)
- As the title says.
- I'd like to put the same process in the session details screen, so I'll deal with it later.

## Links
- Nothing.

## Movie

https://user-images.githubusercontent.com/13657682/192342380-cfabb87b-4624-4b8e-81ee-7ea1d82d95fb.mp4

https://user-images.githubusercontent.com/13657682/192342405-d4c2dd5b-9d55-494c-a0f7-88e41865b476.mp4

https://user-images.githubusercontent.com/13657682/192342442-3fcb7598-4434-4070-b641-cd0e6fcad36d.mp4

![after2](https://user-images.githubusercontent.com/13657682/192342637-727e93a5-b8b1-4986-80bd-bad2c7640bef.gif)
