### PR TITLE
:recycle: Update Enable transition from session details to the search screen.

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -268,7 +268,7 @@ class KaigiAppScaffoldState @OptIn(ExperimentalMaterial3Api::class) constructor(
 
     fun onSearchClick() {
         navController.navigate(
-            route = SessionsNavGraph.sessionSearchRoute(null)
+            route = SessionsNavGraph.sessionSearchRoute()
         )
     }
 

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -84,6 +84,7 @@ import io.github.droidkaigi.confsched2022.feature.staff.StaffNavGraph
 import io.github.droidkaigi.confsched2022.feature.staff.staffNavGraph
 import io.github.droidkaigi.confsched2022.impl.AndroidCalendarRegistration
 import io.github.droidkaigi.confsched2022.impl.AndroidShareManager
+import io.github.droidkaigi.confsched2022.model.TimetableCategory
 import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
 import io.github.droidkaigi.confsched2022.strings.Strings
@@ -125,6 +126,7 @@ fun KaigiApp(
                     showNavigationIcon = showNavigationIcon,
                     onLinkClick = kaigiExternalNavigationController::navigate,
                     onNavigationIconClick = kaigiAppScaffoldState::onNavigationClick,
+                    onCategoryTagClick = kaigiAppScaffoldState::onCategoryTagClick,
                     onBackIconClick = kaigiAppScaffoldState::onBackIconClick,
                     onSearchIconClick = kaigiAppScaffoldState::onSearchClick,
                     onTimetableClick = kaigiAppScaffoldState::onTimeTableClick,
@@ -266,7 +268,15 @@ class KaigiAppScaffoldState @OptIn(ExperimentalMaterial3Api::class) constructor(
 
     fun onSearchClick() {
         navController.navigate(
-            route = SessionsNavGraph.sessionSearchRoute()
+            route = SessionsNavGraph.sessionSearchRoute(null)
+        )
+    }
+
+    fun onCategoryTagClick(
+        category: TimetableCategory?
+    ) {
+        navController.navigate(
+            route = SessionsNavGraph.sessionSearchRoute(category?.id.toString())
         )
     }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -89,7 +89,7 @@ import kotlinx.datetime.toLocalDateTime
 @Composable
 fun SearchRoot(
     modifier: Modifier = Modifier,
-    categoryId: String? = null,
+    initialCategoryId: String? = null,
     viewModel: SearchViewModel = hiltViewModel(),
     onBackIconClick: () -> Unit = {},
     onItemClick: (TimetableItemId) -> Unit,
@@ -100,9 +100,9 @@ fun SearchRoot(
 
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    LaunchedEffect(categoryId) {
-        if (categoryId != null) {
-            viewModel.onCategorySelected(categoryId)
+    LaunchedEffect(initialCategoryId) {
+        if (initialCategoryId != null) {
+            viewModel.onCategorySelected(initialCategoryId)
         }
     }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -100,8 +100,10 @@ fun SearchRoot(
 
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    if (categoryId != null) {
-        viewModel.onCategorySelected(categoryId)
+    LaunchedEffect(categoryId) {
+        if (categoryId != null) {
+            viewModel.onCategorySelected(categoryId)
+        }
     }
 
     LaunchedEffect(state.filterSheetState) {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -89,6 +89,7 @@ import kotlinx.datetime.toLocalDateTime
 @Composable
 fun SearchRoot(
     modifier: Modifier = Modifier,
+    categoryId: String? = null,
     viewModel: SearchViewModel = hiltViewModel(),
     onBackIconClick: () -> Unit = {},
     onItemClick: (TimetableItemId) -> Unit,
@@ -98,6 +99,10 @@ fun SearchRoot(
     val scaffoldState = rememberBottomSheetScaffoldState()
 
     val keyboardController = LocalSoftwareKeyboardController.current
+
+    if (categoryId != null) {
+        viewModel.onCategorySelected(categoryId)
+    }
 
     LaunchedEffect(state.filterSheetState) {
         when (state.filterSheetState) {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SearchViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SearchViewModel.kt
@@ -99,6 +99,20 @@ class SearchViewModel @Inject constructor(
         )
     }
 
+    fun onCategorySelected(categoryId: String) {
+        viewModelScope.launch {
+            val categories = sessionsRepository.getCategories()
+            if (categories.isEmpty())
+                return@launch
+
+            filters.value = filters.value.copy(
+                categories = listOf(
+                    categories.first { it.id.toString() == categoryId }
+                )
+            )
+        }
+    }
+
     fun onDaySelected(day: DroidKaigi2022Day, isSelected: Boolean) {
         val selectedDays = filters.value.days.toMutableList()
         filters.value = filters.value.copy(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -69,6 +69,7 @@ import io.github.droidkaigi.confsched2022.model.KaigiPlace.Prism
 import io.github.droidkaigi.confsched2022.model.Lang
 import io.github.droidkaigi.confsched2022.model.MultiLangText
 import io.github.droidkaigi.confsched2022.model.TimetableAsset
+import io.github.droidkaigi.confsched2022.model.TimetableCategory
 import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.TimetableItem.Session
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
@@ -90,6 +91,7 @@ import java.util.Locale
 fun SessionDetailScreenRoot(
     timetableItemId: TimetableItemId,
     onLinkClick: (url: String) -> Unit,
+    onCategoryTagClick: (TimetableCategory) -> Unit,
     onShareClick: (TimetableItem) -> Unit,
     onRegisterCalendarClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
@@ -105,6 +107,7 @@ fun SessionDetailScreenRoot(
         onRetryButtonClick = { viewModel.onRetryButtonClick() },
         onAppErrorNotified = { viewModel.onAppErrorNotified() },
         onLinkClick = onLinkClick,
+        onCategoryTagClick = onCategoryTagClick,
         onBackIconClick = onBackIconClick,
         onFavoriteClick = { currentFavorite ->
             viewModel.onFavoriteToggle(timetableItemId, currentFavorite)
@@ -148,6 +151,7 @@ fun SessionDetailScreen(
     onAppErrorNotified: () -> Unit,
     modifier: Modifier = Modifier,
     onLinkClick: (url: String) -> Unit = { _ -> },
+    onCategoryTagClick: (category: TimetableCategory) -> Unit = { _ -> },
     onBackIconClick: () -> Unit = {},
     onFavoriteClick: (Boolean) -> Unit = {},
     onShareClick: (TimetableItem) -> Unit = {},
@@ -202,7 +206,10 @@ fun SessionDetailScreen(
                             .verticalScroll(rememberScrollState())
                             .padding(horizontal = 16.dp)
                     ) {
-                        SessionDetailSessionInfo(item = item)
+                        SessionDetailSessionInfo(
+                            onCategoryTagClick = onCategoryTagClick,
+                            item = item,
+                        )
 
                         if (item is Session)
                             SessionDetailDescription(
@@ -294,6 +301,7 @@ fun SessionDetailBottomAppBar(
 @Composable
 fun SessionTagsLine(
     item: TimetableItem,
+    onCategoryTagClick: (category: TimetableCategory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val sessionMinutes =
@@ -336,6 +344,7 @@ fun SessionTagsLine(
             Text(sessionMinutes + "min")
         }
         KaigiTag(
+            modifier = Modifier.clickable { onCategoryTagClick(item.category) },
             backgroundColor = MaterialTheme.colorScheme.secondaryContainer
         ) {
             Text(item.category.title.currentLangTitle)
@@ -417,6 +426,7 @@ fun SessionScheduleInfo(
 @Composable
 fun SessionDetailSessionInfo(
     item: TimetableItem,
+    onCategoryTagClick: (category: TimetableCategory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -428,7 +438,10 @@ fun SessionDetailSessionInfo(
 
         Spacer(modifier = Modifier.padding(24.dp))
 
-        SessionTagsLine(item = item)
+        SessionTagsLine(
+            onCategoryTagClick = onCategoryTagClick,
+            item = item,
+        )
 
         Spacer(modifier = Modifier.padding(24.dp))
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
@@ -4,12 +4,14 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import io.github.droidkaigi.confsched2022.model.TimetableCategory
 import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
 
 fun NavGraphBuilder.sessionsNavGraph(
     showNavigationIcon: Boolean,
     onNavigationIconClick: () -> Unit,
+    onCategoryTagClick: (category: TimetableCategory) -> Unit,
     onLinkClick: (url: String) -> Unit,
     onBackIconClick: () -> Unit,
     onSearchIconClick: () -> Unit,
@@ -39,6 +41,7 @@ fun NavGraphBuilder.sessionsNavGraph(
         val id = it.arguments?.getString("id") ?: ""
         SessionDetailScreenRoot(
             timetableItemId = TimetableItemId(id),
+            onCategoryTagClick = onCategoryTagClick,
             onLinkClick = onLinkClick,
             onBackIconClick = onBackIconClick,
             onNavigateFloorMapClick = onNavigateFloorMapClick,
@@ -48,9 +51,16 @@ fun NavGraphBuilder.sessionsNavGraph(
     }
 
     composable(
-        route = SessionsNavGraph.sessionSearchRoute(),
+        route = SessionsNavGraph.sessionSearchRoute("{id}"),
+        arguments = listOf(
+            navArgument("id") {
+                type = NavType.StringType
+            }
+        )
     ) {
+        val id = it.arguments?.getString("id") ?: ""
         SearchRoot(
+            categoryId = id,
             onItemClick = onTimetableClick,
             onBackIconClick = onBackIconClick,
         )
@@ -62,6 +72,6 @@ object SessionsNavGraph {
     fun sessionDetailRoute(sessionId: String) =
         "session/detail/$sessionId"
 
-    fun sessionSearchRoute() =
-        "session/search"
+    fun sessionSearchRoute(categoryId: String?) =
+        "session/search/$categoryId"
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
@@ -69,7 +69,7 @@ fun NavGraphBuilder.sessionsNavGraph(
     ) {
         val id = it.arguments?.getString("id") ?: ""
         SearchRoot(
-            categoryId = id,
+            initialCategoryId = id,
             onItemClick = onTimetableClick,
             onBackIconClick = onBackIconClick,
         )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionsNavGraph.kt
@@ -51,6 +51,15 @@ fun NavGraphBuilder.sessionsNavGraph(
     }
 
     composable(
+        route = SessionsNavGraph.sessionSearchRoute(),
+    ) {
+        SearchRoot(
+            onItemClick = onTimetableClick,
+            onBackIconClick = onBackIconClick,
+        )
+    }
+
+    composable(
         route = SessionsNavGraph.sessionSearchRoute("{id}"),
         arguments = listOf(
             navArgument("id") {
@@ -72,6 +81,10 @@ object SessionsNavGraph {
     fun sessionDetailRoute(sessionId: String) =
         "session/detail/$sessionId"
 
-    fun sessionSearchRoute(categoryId: String?) =
-        "session/search/$categoryId"
+    fun sessionSearchRoute(categoryId: String? = null) =
+        if (categoryId != null) {
+            "session/search/$categoryId"
+        } else {
+            "session/search"
+        }
 }


### PR DESCRIPTION
## Issue
- Nothing.

## Overview (Required)
- Tapping a category tag now takes you to the search screen.
- When the search screen is displayed, the search will already be performed using the tag displayed in the session details.

## Links
- Nothing.

## Movie

https://user-images.githubusercontent.com/13657682/192979241-9890e0b2-9933-4aa0-9472-cb2640dcbab7.mp4

https://user-images.githubusercontent.com/13657682/192979266-229d4727-a125-46d1-9de5-76bfe4280897.mp4