### PR TITLE
Fix splash screen duration

### DIFF
--- a/app-android/src/main/res/values-night/splash_theme.xml
+++ b/app-android/src/main/res/values-night/splash_theme.xml
@@ -4,7 +4,7 @@
     <style name="Theme.DroidKaigi.SplashTheme" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
         <item name="windowSplashScreenBackground">@android:color/black</item>
-        <item name="windowSplashScreenAnimationDuration">1000</item>
+        <item name="windowSplashScreenAnimationDuration">3000</item>
         <item name="postSplashScreenTheme">@style/Theme.DroidKaigi.NoActionBar</item>
         <item name="android:windowSplashScreenBrandingImage" tools:targetApi="s">@drawable/splash_branding_image</item>
     </style>

--- a/app-android/src/main/res/values/splash_theme.xml
+++ b/app-android/src/main/res/values/splash_theme.xml
@@ -4,7 +4,7 @@
     <style name="Theme.DroidKaigi.SplashTheme" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
         <item name="windowSplashScreenBackground">@android:color/white</item>
-        <item name="windowSplashScreenAnimationDuration">1000</item>
+        <item name="windowSplashScreenAnimationDuration">3000</item>
         <item name="postSplashScreenTheme">@style/Theme.DroidKaigi.NoActionBar</item>
         <item name="android:windowSplashScreenBrandingImage" tools:targetApi="s">@drawable/splash_branding_image</item>
     </style>


### PR DESCRIPTION
## Overview (Required)

Splash animation looks like 3000ms but windowSplashScreenAnimationDuration 1000.

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/7608725/193309332-efec25b3-2f67-4398-9835-9909d7c9e260.gif) | ![after](https://user-images.githubusercontent.com/7608725/193309373-651f2beb-0f9a-449e-8f9c-b89348d43950.gif)

It looks no difference in debug mode...