### PR TITLE
Fix session is not shown when session's time is longer than screen size

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -314,8 +314,8 @@ private data class TimetableItemLayout(
         val xInside =
             left in screenLeft..screenRight || right in screenLeft..screenRight
         val yInside =
-            top in screenTop..screenBottom || bottom in screenTop..screenBottom
-                || (top <= screenTop && screenBottom <= bottom)
+            top in screenTop..screenBottom || bottom in screenTop..screenBottom ||
+                (top <= screenTop && screenBottom <= bottom)
         return xInside && yInside
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -315,6 +315,7 @@ private data class TimetableItemLayout(
             left in screenLeft..screenRight || right in screenLeft..screenRight
         val yInside =
             top in screenTop..screenBottom || bottom in screenTop..screenBottom
+                || (top <= screenTop && screenBottom <= bottom)
         return xInside && yInside
     }
 }


### PR DESCRIPTION
## Issue
- close #824 

## Overview (Required)
- If session's time is longer than screen displayed time then session is not shown.

## Screenshot
Before | After
:--: | :--:
![device-2022-10-01-160123 2022-10-01 16_09_05](https://user-images.githubusercontent.com/7608725/193401494-9f84dd11-3590-4a73-b028-d80e677f9f32.gif) | ![after](https://user-images.githubusercontent.com/7608725/193401589-4752ac35-8d22-4def-9b34-40d6db7773da.gif)
