### PR TITLE
Change navigation icon in session detail screen

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionDetail.kt
@@ -130,8 +130,8 @@ fun SessionDetailTopAppBar(
         navigationIcon = {
             IconButton(onClick = onBackIconClick) {
                 Icon(
-                    painter = painterResource(id = R.drawable.ic_back),
-                    contentDescription = "close"
+                    painter = painterResource(id = R.drawable.ic_baseline_arrow_back_24),
+                    contentDescription = "back"
                 )
             }
         },


### PR DESCRIPTION
## Issue
- close #828 

## Overview (Required)
- fixed close icon to arrow icon in SessionDetailTopAppBar

## Links
- https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=21%3A583

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/83486701/193444947-79b2285a-6fcd-45ad-aec8-80b4a16dcdea.png" width="300" /> | <img src="https://user-images.githubusercontent.com/83486701/193444956-9dd5310d-ece4-4f49-ab52-4973bbd6fc1e.png" width="300" />
