### PR TITLE
:sparkles: Add implement open session detail from notification

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -101,6 +101,7 @@ fun KaigiApp(
     kaigiAppScaffoldState: KaigiAppScaffoldState = rememberKaigiAppScaffoldState(),
     kaigiExternalNavigationController: KaigiExternalNavigationController =
         rememberKaigiExternalNavigationController(),
+    sessionIdFromNotification: String? = null,
 ) {
     val appUiModel: AppUiModel by kaigiAppViewModel.uiModel
 
@@ -173,6 +174,10 @@ fun KaigiApp(
                     onItemClick = kaigiExternalNavigationController::navigate
                 )
             }
+        }
+
+        sessionIdFromNotification?.let {
+            kaigiAppScaffoldState.onTimeTableClick(TimetableItemId(it))
         }
     }
 }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -176,8 +176,10 @@ fun KaigiApp(
             }
         }
 
-        sessionIdFromNotification?.let {
-            kaigiAppScaffoldState.onTimeTableClick(TimetableItemId(it))
+        LaunchedEffect(sessionIdFromNotification) {
+            sessionIdFromNotification?.let {
+                kaigiAppScaffoldState.onTimeTableClick(TimetableItemId(it))
+            }
         }
     }
 }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/MainActivity.kt
@@ -27,8 +27,17 @@ class MainActivity : AppCompatActivity() {
                 Color.argb((255 * 0.5).toInt(), 0, 0, 0)
             }
 
+        val sessionIdString: String? = if (this.intent?.data != null) {
+            this.intent.data.toString()
+        } else {
+            null
+        }
+
         setContent {
-            KaigiApp(calculateWindowSizeClass(this))
+            KaigiApp(
+                windowSizeClass = calculateWindowSizeClass(this),
+                sessionIdFromNotification = sessionIdString
+            )
         }
     }
 }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/notification/AndroidBroadcastReceiver.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/notification/AndroidBroadcastReceiver.kt
@@ -1,8 +1,13 @@
 package io.github.droidkaigi.confsched2022.notification
 
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import androidx.core.app.TaskStackBuilder
+import androidx.core.net.toUri
+import io.github.droidkaigi.confsched2022.MainActivity
 import io.github.droidkaigi.confsched2022.feature.sessions.SessionAlarm.Companion.EXTRA_CHANNEL_ID
 import io.github.droidkaigi.confsched2022.feature.sessions.SessionAlarm.Companion.EXTRA_SESSION_ID
 import io.github.droidkaigi.confsched2022.feature.sessions.SessionAlarm.Companion.EXTRA_TEXT
@@ -17,7 +22,30 @@ class AndroidBroadcastReceiver : BroadcastReceiver() {
         val title = intent.getStringExtra(EXTRA_TITLE) ?: return
         val text = intent.getStringExtra(EXTRA_TEXT) ?: return
         val channelId = intent.getStringExtra(EXTRA_CHANNEL_ID) ?: return
+        val deepLinkIntent = Intent(
+            Intent.ACTION_VIEW,
+            sessionId.toUri(),
+            context,
+            MainActivity::class.java
+        )
 
-        NotificationUtil.showNotification(context, title, text, channelId)
+        TaskStackBuilder.create(context).run {
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+
+            addNextIntentWithParentStack(deepLinkIntent)
+            getPendingIntent(0, flags)
+        }?.let { deepLinkPendingIntent ->
+            NotificationUtil.showNotification(
+                context,
+                title,
+                text,
+                channelId,
+                deepLinkPendingIntent
+            )
+        }
     }
 }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/notification/NotificationUtil.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/notification/NotificationUtil.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2022.notification
 import android.Manifest.permission
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
@@ -17,7 +18,8 @@ object NotificationUtil {
         context: Context,
         title: String,
         text: String,
-        channelId: String
+        channelId: String,
+        pendingIntent: PendingIntent,
     ) {
         val notificationBuilder = notificationBuilder(
             context,
@@ -27,7 +29,8 @@ object NotificationUtil {
                 showBundleNotification(
                     context,
                     title,
-                    channelId
+                    channelId,
+                    pendingIntent,
                 )
                 setGroup(channelId)
             } else {
@@ -38,6 +41,7 @@ object NotificationUtil {
                 NotificationCompat.BigTextStyle()
                     .bigText(text)
             )
+            setContentIntent(pendingIntent)
             setAutoCancel(true)
             setSmallIcon(io.github.droidkaigi.confsched2022.core.designsystem.R.drawable.ic_app)
         }
@@ -61,7 +65,12 @@ object NotificationUtil {
     }
 
     @RequiresApi(Build.VERSION_CODES.N)
-    private fun showBundleNotification(context: Context, title: String, channelId: String) {
+    private fun showBundleNotification(
+        context: Context,
+        title: String,
+        channelId: String,
+        pendingIntent: PendingIntent,
+    ) {
         val notificationManager = context.getSystemService(NotificationManager::class.java)
         val notification = notificationBuilder(
             context,
@@ -74,6 +83,7 @@ object NotificationUtil {
             .setSmallIcon(io.github.droidkaigi.confsched2022.core.designsystem.R.drawable.ic_app)
             .setGroup(channelId)
             .setGroupSummary(true)
+            .setContentIntent(pendingIntent)
             .setAutoCancel(true)
             .build()
         notificationManager.notify(channelId.hashCode(), notification)

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionAlarm.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionAlarm.kt
@@ -98,11 +98,17 @@ class SessionAlarm @Inject constructor(private val app: Application) {
             text
         )
 
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+
         return PendingIntent.getBroadcast(
             app,
             timetableItem.id.hashCode(),
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            flags,
         )
     }
 


### PR DESCRIPTION
## Issue
- close #810 

## Overview (Required)
- Fixed crash when displaying notifications.
- SessionDetail is now opened when a notification is tapped.

## Links
- https://developer.android.com/jetpack/compose/navigation?hl=ja
- https://stackoverflow.com/a/70973229

## Movie

https://user-images.githubusercontent.com/13657682/193452134-f55955fe-c22d-4f81-9931-2723283baa41.mp4