### PR TITLE
Togglable dynamic color settings item

### DIFF
--- a/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
+++ b/feature/setting/src/main/java/io/github/droidkaigi/confsched2022/feature/setting/Setting.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Colorize
 import androidx.compose.material.icons.filled.Language
@@ -26,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
@@ -101,7 +104,8 @@ private fun LanguageSetting(
     Row(
         modifier = modifier
             .clickable { openDialog.value = true }
-            .padding(16.dp)
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 16.dp)
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
@@ -183,7 +187,13 @@ private fun DynamicColorSetting(
 ) {
     Row(
         modifier = modifier
-            .padding(16.dp)
+            .toggleable(
+                value = isDynamicColorEnabled,
+                role = Role.Switch,
+                onValueChange = { onDynamicColorToggle(it) }
+            )
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 16.dp)
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(28.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -195,9 +205,7 @@ private fun DynamicColorSetting(
         )
         Switch(
             checked = isDynamicColorEnabled,
-            onCheckedChange = {
-                onDynamicColorToggle(it)
-            },
+            onCheckedChange = null,
         )
     }
 }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Changed the dynamic color settings item to be clickable.
- Adjust the height of items on the setting screen.  

## Links
- https://developer.android.com/jetpack/compose/accessibility#:~:text=When%20implementing%20selection%20controls%20like%20Switch%2C%20RadioButton%2C%20or%20Checkbox%2C%20you%20typically%20lift%20the%20clickable%20behavior%20to%20a%20parent%20container%2C%20set%20the%20click%20callback%20on%20the%20composable%20to%20null%2C%20and%20add%20a%20toggleable%20or%20selectable%20modifier%20to%20the%20parent%20composable.

## Screenshot


https://user-images.githubusercontent.com/13705006/193733114-9c0d531b-ec81-4c22-b366-2fa7ee92918a.mp4


