### PR TITLE
Fixed access item height

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2022/feature/about/About.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -263,7 +263,7 @@ private fun AuxiliaryInformationRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(56.dp)
+            .heightIn(min = 56.dp)
             .clickable { onClick() },
         verticalAlignment = Alignment.CenterVertically
     ) {


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Adjusted the height of items because the access description was not displayed on certain devices.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13705006/193736631-765b5aea-4ce1-4935-a62c-43cf67aec01f.png" width="300" />|<img src="https://user-images.githubusercontent.com/13705006/193736636-fae8eb27-1dbf-429c-987c-1eff62ca9b62.png" width="300" /> 
