### PR TITLE
Session title reflects application settings

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
                 api(libs.mokoResourcesCompose)
 
                 implementation(libs.composeRuntime)
+                implementation(libs.androidxAppCompat)
             }
         }
     }

--- a/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
+++ b/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched2022/model/Locale.kt
@@ -1,8 +1,21 @@
 package io.github.droidkaigi.confsched2022.model
 
-public actual fun getDefaultLocale(): Locale =
-    if (java.util.Locale.getDefault() == java.util.Locale.JAPAN) {
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+
+public actual fun getDefaultLocale(): Locale {
+    val applicationLocales = AppCompatDelegate.getApplicationLocales()
+    if (!applicationLocales.isEmpty) {
+        return if (applicationLocales == LocaleListCompat.forLanguageTags("ja")) {
+            Locale.JAPAN
+        } else {
+            Locale.OTHER
+        }
+    }
+
+    return if (java.util.Locale.getDefault() == java.util.Locale.JAPAN) {
         Locale.JAPAN
     } else {
         Locale.OTHER
     }
+}


### PR DESCRIPTION
## Issue
- close none

## Overview (Required)
- Language is set in the application settings but not reflected in the session title.
- Modified to check applicationLocales and select language if applicationLocales exists.

## Links
- 

## Screenshot

Before

[!(main webm)](https://user-images.githubusercontent.com/17231507/194066067-38fec028-b148-4ecf-bd59-313d9e6aa19f.webm)

After

 [!(fix webm)](https://user-images.githubusercontent.com/17231507/194066211-3c5ae0fa-b49b-4c7e-a0ff-f8eef7dfb0ec.webm)

