### PR TITLE
reflect click event of checkbox on search filter

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SearchFilterSheets.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SearchFilterSheets.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.IconButton
@@ -20,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -85,7 +87,9 @@ fun FilterDaySheet(
 
                 Checkbox(
                     checked = selectedDays.contains(kaigiDay),
-                    onCheckedChange = {},
+                    onCheckedChange = null,
+                    modifier = Modifier
+                        .size(LocalViewConfiguration.current.minimumTouchTargetSize),
                     colors = CheckboxDefaults.colors(
                         checkedColor = MaterialTheme.colorScheme.primary,
                         uncheckedColor = MaterialTheme.colorScheme.primary
@@ -139,7 +143,9 @@ fun FilterCategoriesSheet(
                 ) {
                     Checkbox(
                         checked = selectedCategories.contains(category),
-                        onCheckedChange = {},
+                        onCheckedChange = null,
+                        modifier = Modifier
+                            .size(LocalViewConfiguration.current.minimumTouchTargetSize),
                         colors = CheckboxDefaults.colors(
                             checkedColor = MaterialTheme.colorScheme.primary,
                             uncheckedColor = MaterialTheme.colorScheme.primary


### PR DESCRIPTION
## Issue
- close #849

## Overview (Required)
- On search filter, click event of checkboxes weren't dealt
- enable to toggle filters by also tapping checkboxes themselves
- I noticed that Day Filter has same issue, so I modified both filters (day/category)

## Links
- [App Design](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1)
- [Accessibility in Compose](https://developer.android.com/jetpack/compose/accessibility)

## Screenshot
Before | After
:--: | :--:
<video src="https://user-images.githubusercontent.com/74723074/194279565-a793dd60-db29-4a0c-be9d-6fc42e886ddd.mp4" type="video/mp4" /> | <video src="https://user-images.githubusercontent.com/74723074/194279590-071bfbe0-9047-4d39-8398-fa871a54a836.mp4" type="video/mp4" />
<video src="https://user-images.githubusercontent.com/74723074/194279803-c1f68cee-75ac-4f3a-b725-1dbde489f794.mp4" type="video/mp4" /> | <video src="https://user-images.githubusercontent.com/74723074/194279829-1a70399a-2b63-49d3-afb6-7896c5b57ac2.mp4" type="video/mp4" />








