### PR TITLE
Adapt design to updated material3 library(v1.0.0-rc01)

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -365,7 +365,12 @@ private fun SearchTextField(
                 },
                 singleLine = true,
                 enabled = true,
-                colors = TextFieldDefaults.textFieldColors(),
+                colors = TextFieldDefaults.textFieldColors(
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                    errorIndicatorColor = Color.Transparent,
+                ),
                 interactionSource = remember { MutableInteractionSource() },
                 contentPadding = PaddingValues(
                     top = 16.dp,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Search.kt
@@ -365,19 +365,15 @@ private fun SearchTextField(
                 },
                 singleLine = true,
                 enabled = true,
-                colors = TextFieldDefaults.textFieldColors(
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                    disabledIndicatorColor = Color.Transparent,
-                    errorIndicatorColor = Color.Transparent,
-                ),
+                colors = TextFieldDefaults.textFieldColors(),
                 interactionSource = remember { MutableInteractionSource() },
                 contentPadding = PaddingValues(
                     top = 16.dp,
                     bottom = 16.dp,
                     start = 0.dp,
                     end = 16.dp
-                )
+                ),
+                container = {},
             )
         }
     )


### PR DESCRIPTION
## Issue
- close #860

## Overview (Required)
- When Renovate updated material3 to v1.0.0-rc01, there were differences on search box (bottom line appeared)
- Fit ui to design

## Links
- [App Design](https://www.figma.com/file/NcSMs6dMsD88d4wOY0g3rK/DroidKaigi-2022-Conference-App?node-id=0%3A1)
- [compose-material3](https://developer.android.com/jetpack/androidx/releases/compose-material3)
- [commits between beta03 and rc01](https://android.googlesource.com/platform/frameworks/support/+/b2c3164b907798ad87c70db5c2d35b0745f1948f)

## Screenshot
Branch | Images
:--: | :--:
main | <img src="https://user-images.githubusercontent.com/74723074/194457996-d09c848e-01be-4b31-a991-008aab6721ef.png" width="250" /> <img src="https://user-images.githubusercontent.com/74723074/194458001-101e4db4-465e-4407-b4ab-fe80f5b4b74d.png" width="250" />
renovate/composematerial3 | <img src="https://user-images.githubusercontent.com/74723074/194458222-8a0c2af8-ad2b-4916-9f14-b4943b1a344f.png" width="250" /> <img src="https://user-images.githubusercontent.com/74723074/194458225-8530f4f7-a86f-46e9-983d-3f8bf80ed43d.png" width="250" />
composematerial3-adaption | <img src="https://user-images.githubusercontent.com/74723074/194458418-6655046c-9fbe-4d92-888e-f9891b91b17d.png" width="250" /> <img src="https://user-images.githubusercontent.com/74723074/194458421-4b8f2e6f-b001-4f7b-b426-7a447a1709f3.png" width="250" />



