### PR TITLE
[Refactoring] Replace mapIndexed with List generator in Hours

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
@@ -167,7 +167,7 @@ private data class HoursLayout(
     var hoursHeight = 0
     var hoursWidth = 0
     val minutePx = with(density) { TimetableSizes.minuteHeight.times(verticalScale).toPx() }
-    val hoursLayouts = hours.mapIndexed { index, it ->
+    val hoursLayouts = List(hours.size) { index ->
         val hoursItemLayout = HoursItemLayout(
             index = index,
             density = density,


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I replaced `mapIndexed` with List generator in Hours to fix a lint warning.

## Out of scope in this PR
I also found the same lint warning in another file, but let me separate PR to make PR smaller and a PR review easier.

## Links
- n/a

## Screenshot
<img width="728" alt="スクリーンショット 2022-10-07 13 54 45" src="https://user-images.githubusercontent.com/8059722/194472414-5baa84b1-0b66-4ffe-858f-91d5c7f70fd2.png">
