### PR TITLE
[Bugfix] Check that scroll offset is not Float.NAN before scroll

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
@@ -269,11 +269,13 @@ private class HoursScreen(
         position: Offset,
     ) {
         val nextPossibleY = calculatePossibleScrollY(dragAmount.y)
-        scrollState.scroll(
-            Offset(scrollState.scrollX, nextPossibleY),
-            timeMillis,
-            position
-        )
+        if (scrollState.scrollX.isNaN().not() && nextPossibleY.isNaN().not()) {
+            scrollState.scroll(
+                Offset(scrollState.scrollX, nextPossibleY),
+                timeMillis,
+                position
+            )
+        }
     }
 
     private fun calculatePossibleScrollY(scrollY: Float): Float {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
@@ -252,11 +252,13 @@ private class RoomScreen(
         position: Offset,
     ) {
         val nextPossibleX = calculatePossibleScrollX(dragAmount.x)
-        scrollState.scroll(
-            Offset(nextPossibleX, scrollState.scrollY),
-            timeMillis,
-            position
-        )
+        if (nextPossibleX.isNaN().not() && scrollState.scrollY.isNaN().not()) {
+            scrollState.scroll(
+                Offset(nextPossibleX, scrollState.scrollY),
+                timeMillis,
+                position
+            )
+        }
     }
 
     private fun calculatePossibleScrollX(scrollX: Float): Float {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Timetable.kt
@@ -192,11 +192,13 @@ fun Timetable(
                 scrollBy(
                     action = { x: Float, y: Float ->
                         coroutineScope.launch {
-                            scrollState.scroll(
-                                amount = Offset(x, y),
-                                timeMillis = 0,
-                                position = Offset.Zero
-                            )
+                            if (x.isNaN().not() && y.isNaN().not()) {
+                                scrollState.scroll(
+                                    amount = Offset(x, y),
+                                    timeMillis = 0,
+                                    position = Offset.Zero
+                                )
+                            }
                         }
                         return@scrollBy true
                     }
@@ -594,11 +596,13 @@ private class TimetableScreen(
     ) {
         val nextPossibleX = calculatePossibleScrollX(dragAmount.x)
         val nextPossibleY = calculatePossibleScrollY(dragAmount.y)
-        scrollState.scroll(
-            Offset(nextPossibleX, nextPossibleY),
-            timeMillis,
-            position
-        )
+        if (nextPossibleX.isNaN().not() && nextPossibleY.isNaN().not()) {
+            scrollState.scroll(
+                Offset(nextPossibleX, nextPossibleY),
+                timeMillis,
+                position
+            )
+        }
     }
 
     fun enableHorizontalScroll(dragX: Float): Boolean {


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2022/issues/795

## Overview (Required)

The crash is Caused by creating an instance of Offset with `Float.NAN`, but I can't find the root cause of it.
In other words, I can't find a division by `0f` on the call hierarchy.

So I added an `if` block to prevent scroll with an invalid offset.

This does not fix the root cause, but I think this will work.


## Screenshot

I can't reproduce the crash on my env, so no screen recording.

