### PR TITLE
[Refactoring] Remove unused variable from Hours

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Hours.kt
@@ -201,7 +201,6 @@ private data class HoursItemLayout(
     val width = with(density) { hoursWidth.roundToPx() }
     val left = 0
     val top = index * height + topOffset - itemOffset
-    val right = left + width
     val bottom = top + height
 
     fun isVisible(


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I removed unused variable from Hours to fix a lint warning.
I'm not sure anyone plan to use this unused `right` variable in the future, but I think it should be removed for now as _[YAGNI principal](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it)_.

## Links
- n/a

## Screenshot

<img width="639" alt="スクリーンショット 2022-10-07 14 21 32" src="https://user-images.githubusercontent.com/8059722/194475462-3ae25580-3335-43d6-b6af-494e3dbc00d7.png">
