### PR TITLE
[Refactoring] Replace mapIndexed with List generator in Rooms

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
@@ -158,7 +158,7 @@ private data class RoomsLayout(
 ) {
     var roomsWidth = 0
     var roomsHeight = 0
-    val roomsLayouts = rooms.mapIndexed { index, _ ->
+    val roomsLayouts = List(rooms.size) { index ->
         val itemLayout = RoomItemLayout(
             index = index,
             density = density


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I replaced `mapIndexed` with List generator in Rooms to fix a lint warning.

## Links
- Related PR: https://github.com/DroidKaigi/conference-app-2022/pull/877

## Screenshot

<img width="550" alt="スクリーンショット 2022-10-07 14 49 43" src="https://user-images.githubusercontent.com/8059722/194477071-db150033-7ca1-4dc8-97be-80cb59380ac0.png">


