### PR TITLE
[Refactoring] Remove unused variable from Rooms

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Rooms.kt
@@ -188,7 +188,6 @@ private data class RoomItemLayout(
     val left = index * width
     val top = 0
     val right = left + width
-    val bottom = top + height
 
     fun isVisible(
         screenWidth: Int,


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I removed unused variable from Rooms to fix a lint warning.
I'm not sure anyone plan to use this unused variable in the future, but I think it should be removed for now as _[YAGNI principal](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it)_.

## Links
- Related PR: https://github.com/DroidKaigi/conference-app-2022/pull/879

## Screenshot

<img width="618" alt="スクリーンショット 2022-10-07 14 52 13" src="https://user-images.githubusercontent.com/8059722/194477445-c5b2d666-2496-4ce8-9812-41b26e5ccb31.png">


