### PR TITLE
[Refactoring] Remove redundant receiver parameter in KaigiApp

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -382,7 +382,7 @@ enum class DrawerItem(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ColumnScope.DrawerSheetContent(
+fun DrawerSheetContent(
     selectedDrawerItem: DrawerItem?,
     onClickDrawerItem: (DrawerItem) -> Unit
 ) {


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I removed the redundant receiver parameter in KaigiApp to fix a lint warning.

## Links
- n/a

## Screenshot
<img width="568" alt="スクリーンショット 2022-10-07 15 11 25" src="https://user-images.githubusercontent.com/8059722/194480002-092b3d03-8768-4eff-8b5e-455cfff86a42.png">


