### PR TITLE
[Refactoring] Convert lambda to reference in AnnouncementsApi

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/announcement/AnnouncementsApi.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/data/announcement/AnnouncementsApi.kt
@@ -37,7 +37,7 @@ private fun AnnouncementsResponse.toAnnouncementsByDate(): PersistentList<Announ
                         id = response.id,
                         title = response.title,
                         content = response.content,
-                        type = response.type.lowercase().replaceFirstChar { it.uppercase() },
+                        type = response.type.lowercase().replaceFirstChar(Char::uppercase),
                         language = response.language,
                     )
                 }.toPersistentList()


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I converted lambda to reference in AnnouncementsApi to fix a lint warning that the implicit parameter `it`  of enclosing lambda is shadowed.

## Links
- n/a

## Screenshot
<img width="489" alt="スクリーンショット 2022-10-07 15 28 57" src="https://user-images.githubusercontent.com/8059722/194482870-d9c509c3-8105-4e5d-b36a-490854a11fbe.png">

