### PR TITLE
[Refactoring] Make DrawerItem.group private in KaigiApp

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2022/KaigiApp.kt
@@ -324,7 +324,7 @@ enum class DrawerGroup {
 }
 
 enum class DrawerItem(
-    val group: DrawerGroup,
+    private val group: DrawerGroup,
     val titleStringRes: StringResource,
     val icon: ImageVector,
     val navRoute: String


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I made `DrawerItem.group` private in KaigiApp to fix a lint warning.

## Links
- n/a

## Screenshot

<img width="463" alt="スクリーンショット 2022-10-07 15 44 13" src="https://user-images.githubusercontent.com/8059722/194484776-699db681-7217-42f5-af69-3976ca002326.png">
