### PR TITLE
Add test cases for AboutScreenRobot to assert AuxiliaryInformation

### DIFF
--- a/feature/about/src/test/java/io/github/droidkaigi/confsched2022/feature/about/AboutScreenRobot.kt
+++ b/feature/about/src/test/java/io/github/droidkaigi/confsched2022/feature/about/AboutScreenRobot.kt
@@ -13,6 +13,14 @@ class AboutScreenRobot @Inject constructor() {
         composeTestRule.onNodeWithContentDescription("Twitter").assertExists()
         composeTestRule.onNodeWithContentDescription("YouTube").assertExists()
         composeTestRule.onNodeWithContentDescription("Medium").assertExists()
+
+        // AuxiliaryInformation
+        composeTestRule.onNodeWithText("Access")
+        composeTestRule.onNodeWithText("Staff List")
+        composeTestRule.onNodeWithText("License")
+        composeTestRule.onNodeWithText("Code Conduct")
+        composeTestRule.onNodeWithText("Privacy Policy")
+        composeTestRule.onNodeWithText("App Version")
     }
 
     operator fun invoke(


### PR DESCRIPTION
## Issue
- n/a

## Overview (Required)
In this PR, I added test cases for AboutScreenRobot to make sure that the below elements are visible.
* Access
* Staff List
* License
* Code Conduct
* Privacy Policy
* App Version

## Links
- n/a

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8059722/194495724-66f88d78-21de-4695-917b-a96aa41dc837.png" width="300" /> | No changes (same as before)

The test has been passed locally. ✅ 
<img width="881" alt="スクリーンショット 2022-10-07 16 25 12" src="https://user-images.githubusercontent.com/8059722/194496580-50ad3dae-0ba4-4f02-b105-2de0d1496b5e.png">

