### PR TITLE
[iOS] Fix app crash when network issues occur

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/AnnouncementsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/AnnouncementsRepository.kt
@@ -2,8 +2,10 @@ package io.github.droidkaigi.confsched2022.model
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
+import kotlin.coroutines.cancellation.CancellationException
 
 public interface AnnouncementsRepository {
     public fun announcements(): Flow<PersistentList<AnnouncementsByDate>>
+    @Throws(AppError::class, CancellationException::class)
     public suspend fun refresh()
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/ContributorsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/ContributorsRepository.kt
@@ -2,8 +2,10 @@ package io.github.droidkaigi.confsched2022.model
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
+import kotlin.coroutines.cancellation.CancellationException
 
 public interface ContributorsRepository {
     public fun contributors(): Flow<PersistentList<Contributor>>
+    @Throws(AppError::class, CancellationException::class)
     public suspend fun refresh()
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/SessionsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/SessionsRepository.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2022.model
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlin.coroutines.cancellation.CancellationException
 
 public interface SessionsRepository {
     public fun droidKaigiScheduleFlow(): Flow<DroidKaigiSchedule>
@@ -15,6 +16,7 @@ public interface SessionsRepository {
 
     public suspend fun getCategories(): List<TimetableCategory>
 
+    @Throws(AppError::class, CancellationException::class)
     public suspend fun refresh()
     public suspend fun setFavorite(sessionId: TimetableItemId, favorite: Boolean)
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/SponsorsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/SponsorsRepository.kt
@@ -2,9 +2,10 @@ package io.github.droidkaigi.confsched2022.model
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
+import kotlin.coroutines.cancellation.CancellationException
 
 public interface SponsorsRepository {
     public fun sponsors(): Flow<PersistentList<Sponsor>>
-
+    @Throws(AppError::class, CancellationException::class)
     public suspend fun refresh()
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/StaffRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2022/model/StaffRepository.kt
@@ -2,9 +2,10 @@ package io.github.droidkaigi.confsched2022.model
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
+import kotlin.coroutines.cancellation.CancellationException
 
 public interface StaffRepository {
     public fun staff(): Flow<PersistentList<Staff>>
-
+    @Throws(AppError::class, CancellationException::class)
     public suspend fun refresh()
 }


### PR DESCRIPTION
## Issue
- close #874

## Overview (Required)

- This PR adds `@Throws` annotations to fix app crash when network issues occur
- [The document](https://kotlinlang.org/docs/native-objc-interop.html#errors-and-exceptions) says:

> When Kotlin function called from Swift/Objective-C code throws an exception which is an instance of one of the `@Throws`-specified classes or their subclasses, it is propagated as `NSError`. Other Kotlin exceptions reaching Swift/Objective-C are considered unhandled and cause program termination.
>
> `suspend` functions without `@Throws` propagate only `CancellationException` as `NSError`. Non-`suspend` functions without `@Throws` don't propagate Kotlin exceptions at all.

## Links
- https://kotlinlang.org/docs/native-objc-interop.html#errors-and-exceptions
- https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-throws/

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
