### PR TITLE
Show TimeLane even if the visibleItemsInfo is empty

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimeLane.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimeLane.kt
@@ -23,6 +23,23 @@ fun TimeLane(
         }
     }
     var currentDurationTime: DurationTime? = null
+
+    if (visibleItemsInfo.value.isEmpty()) {
+        // For preview
+        val durationTime = timetable[0].first
+        Box(
+            modifier = modifier.offset {
+                IntOffset(
+                    x = 0,
+                    y = 0,
+                )
+            }
+        ) {
+            content(durationTime)
+        }
+        return
+    }
+
     visibleItemsInfo.value.forEachIndexed { visibleItemIndex, visibleItemInfo ->
         val durationTime = timetable[visibleItemInfo.index].first
         if (currentDurationTime != durationTime) {


### PR DESCRIPTION
## Issue
- close #832 

## Overview (Required)
- Show TimeLane on the Preview of Android Studio

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1172478/195123531-d28bbce8-dfb3-4872-9389-a091b2b5fd22.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1172478/195123557-a630ed66-e964-4eb0-ae22-df6facb56b5d.png" width="300" />
