### PR TITLE
Update: reduce recomposition of TimeLane

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
@@ -27,10 +27,11 @@ import io.github.droidkaigi.confsched2022.model.TimetableItem
 import io.github.droidkaigi.confsched2022.model.TimetableItemId
 import io.github.droidkaigi.confsched2022.model.TimetableItemWithFavorite
 import io.github.droidkaigi.confsched2022.strings.Strings
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun SessionList(
-    timetable: List<Pair<DurationTime, TimetableItemWithFavorite>>,
+    timetable: ImmutableList<Pair<DurationTime, TimetableItemWithFavorite>>,
     sessionsListListState: LazyListState,
     onTimetableClick: (timetableItemId: TimetableItemId) -> Unit,
     onFavoriteClick: (TimetableItem, Boolean) -> Unit,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
@@ -16,9 +16,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.CustomAccessibilityAction

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/SessionList.kt
@@ -9,12 +9,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.CustomAccessibilityAction
@@ -28,6 +32,7 @@ import io.github.droidkaigi.confsched2022.model.TimetableItemId
 import io.github.droidkaigi.confsched2022.model.TimetableItemWithFavorite
 import io.github.droidkaigi.confsched2022.strings.Strings
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun SessionList(
@@ -38,12 +43,24 @@ fun SessionList(
     modifier: Modifier = Modifier,
     content: @Composable (Pair<DurationTime?, TimetableItemWithFavorite>) -> Unit,
 ) {
+    val visibleItemsInfo by remember {
+        derivedStateOf {
+            sessionsListListState.layoutInfo.visibleItemsInfo
+        }
+    }
+    val visibleItemIndices by remember {
+        derivedStateOf {
+            visibleItemsInfo.map(LazyListItemInfo::index)
+                .toImmutableList()
+        }
+    }
     Box(
         modifier = modifier,
     ) {
         TimeLane(
             timetable = timetable,
-            sessionsListListState = sessionsListListState
+            visibleItemIndices = visibleItemIndices,
+            getVisibleItemOffset = { visibleItemsInfo[it].offset },
         ) { durationTime ->
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/Sessions.kt
@@ -339,7 +339,7 @@ fun SessionsList(
                 val endTime = endLocalDateTime.time.toString()
                 list.add(Pair(DurationTime(startTime, endTime), timetableItemWithFavorite))
             }
-            list.toList()
+            list.toImmutableList()
         }
         SessionList(
             timetable = timeHeaderAndTimetableItems,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimeLane.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimeLane.kt
@@ -2,10 +2,7 @@ package io.github.droidkaigi.confsched2022.feature.sessions
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import io.github.droidkaigi.confsched2022.model.TimetableItemWithFavorite
@@ -14,28 +11,24 @@ import kotlinx.collections.immutable.ImmutableList
 @Composable
 fun TimeLane(
     timetable: ImmutableList<Pair<DurationTime, TimetableItemWithFavorite>>,
-    sessionsListListState: LazyListState,
+    visibleItemIndices: ImmutableList<Int>,
+    getVisibleItemOffset: (index: Int) -> Int,
     modifier: Modifier = Modifier,
     content: @Composable (DurationTime) -> Unit,
 ) {
-    val visibleItemsInfo = remember {
-        derivedStateOf {
-            sessionsListListState.layoutInfo.visibleItemsInfo
-        }
-    }
     var currentDurationTime: DurationTime? = null
-    visibleItemsInfo.value.forEachIndexed { visibleItemIndex, visibleItemInfo ->
-        val durationTime = timetable[visibleItemInfo.index].first
+    visibleItemIndices.forEachIndexed { relativeIndex, absoluteIndex ->
+        val durationTime = timetable[absoluteIndex].first
         if (currentDurationTime != durationTime) {
             currentDurationTime = durationTime
-            val nextDurationTime = timetable.getOrNull(visibleItemInfo.index + 1)?.first
+            val nextDurationTime = timetable.getOrNull(absoluteIndex + 1)?.first
             Box(
                 modifier = modifier.offset {
                     IntOffset(
                         x = 0,
-                        y = if (visibleItemIndex == 0 &&
+                        y = if (relativeIndex == 0 &&
                             durationTime == nextDurationTime
-                        ) 0 else visibleItemInfo.offset,
+                        ) 0 else getVisibleItemOffset(relativeIndex),
                     )
                 }
             ) {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimeLane.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2022/feature/sessions/TimeLane.kt
@@ -9,10 +9,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import io.github.droidkaigi.confsched2022.model.TimetableItemWithFavorite
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun TimeLane(
-    timetable: List<Pair<DurationTime, TimetableItemWithFavorite>>,
+    timetable: ImmutableList<Pair<DurationTime, TimetableItemWithFavorite>>,
     sessionsListListState: LazyListState,
     modifier: Modifier = Modifier,
     content: @Composable (DurationTime) -> Unit,


### PR DESCRIPTION
## Issue
- close #867 

## Overview (Required)
TimeLane composable is recomposed by every scroll, so we should reduce recomposition.
- change `List` to `ImmutableList`
- `LazyListItemInfo#offset` is changed by every scroll, but it is used only for changing offset of Box composable, so we can pass it by lambda function
  - TimeLane composable will be recomposed by changing visible items
  - `LazyListItemInfo#index` is not changed by every scroll

## Links
- 

## Screenshot
No change in appearance

## Note

I have no idea how we can use `drawBehind()` to solve this problem.
If you have it, please give me advice.

I'm sorry for being late 🙏 